### PR TITLE
Improved inspector + Added a static instance scanner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ if(MSVC)
     target_compile_options(UnityInspector PRIVATE /bigobj)
 
     target_compile_options(UnityInspector PRIVATE
+            /EHa
             $<$<CONFIG:RELEASE>:/O2>
             $<$<CONFIG:RELEASE>:/GL>
             $<$<CONFIG:RELEASE>:/GS->
@@ -98,3 +99,12 @@ if(DEFINED ENV{CI})
 
     message(STATUS "CI detected: set static seed for xorstr (to avoid cache misses caused by __TIME__ computed at build time)")
 endif()
+
+# Auto-install to /dist as winhttp.dll after building
+add_custom_command(TARGET UnityInspector POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_SOURCE_DIR}/dist"
+    COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:UnityInspector>" "${CMAKE_SOURCE_DIR}/dist/winhttp.dll"
+    COMMAND powershell -NoProfile -Command "Copy-Item -Path '$<TARGET_PDB_FILE:UnityInspector>' -Destination '${CMAKE_SOURCE_DIR}/dist/winhttp.pdb' -Force -ErrorAction SilentlyContinue; exit 0"
+    COMMAND powershell -NoProfile -Command "Copy-Item -Path '$<TARGET_FILE_DIR:UnityInspector>/*.idb' -Destination '${CMAKE_SOURCE_DIR}/dist/' -Force -ErrorAction SilentlyContinue; exit 0"
+    COMMENT "Installing UnityInspector to dist/winhttp.dll..."
+)

--- a/UnityInspector/src/features/inspector/field_editor.cpp
+++ b/UnityInspector/src/features/inspector/field_editor.cpp
@@ -66,23 +66,18 @@ static void CheckAndUpdateEnumType(std::string& typeName, const std::string& fie
 {
 	if (enumTypeNameOut) enumTypeNameOut->clear();
 
-	if (fieldTypeName == "System.Int32")
-	{
-		const size_t lastDot = typeName.rfind('.');
+	const size_t lastDot = typeName.rfind('.');
+	const std::string shortName = (lastDot != std::string::npos) ? typeName.substr(lastDot + 1) : typeName;
 
-		if (const std::string shortName = (lastDot != std::string::npos) ? typeName.substr(lastDot + 1) : typeName; IsEnumClass(shortName))
-		{
-			typeName = "Enum";
-			if (enumTypeNameOut) *enumTypeNameOut = shortName;
-		}
-		else if (lastDot != std::string::npos)
-		{
-			if (const std::string fullName = typeName.substr(lastDot + 1); IsEnumClass(fullName))
-			{
-				typeName = "Enum";
-				if (enumTypeNameOut) *enumTypeNameOut = fullName;
-			}
-		}
+	if (IsEnumClass(shortName))
+	{
+		typeName = "Enum";
+		if (enumTypeNameOut) *enumTypeNameOut = shortName;
+	}
+	else if (IsEnumClass(fieldTypeName))
+	{
+		typeName = "Enum";
+		if (enumTypeNameOut) *enumTypeNameOut = fieldTypeName;
 	}
 }
 
@@ -115,10 +110,8 @@ EditableType DetermineEditableType(const std::string& typeName, std::string* enu
         return EditableType::Quaternion;
     if (typeName == "UnityEngine.Color")
         return EditableType::Color;
-    if (!typeName.starts_with("System.") && !typeName.starts_with("UnityEngine."))
-        return EditableType::CustomObject;
 
-    return EditableType::None;
+    return EditableType::CustomObject;
 }
 
 FieldEditor::FieldEditor() = default;

--- a/UnityInspector/src/features/inspector/inspector.cpp
+++ b/UnityInspector/src/features/inspector/inspector.cpp
@@ -37,73 +37,248 @@ void Inspector::Render()
 
 	if (ImGui::Begin("Hierarchy", nullptr))
 	{
-		if (ImGui::Button("Refresh"))
-			RefreshHierarchy();
-
-		ImGui::SameLine();
-		ImGui::Checkbox("Auto", &Config::settings.inspector.autoRefresh);
-
-		ImGui::SameLine();
-		if (ImGui::SmallButton("Collapse"))
-			SetAllNodesExpanded(rootNodes, false);
-
-		ImGui::SameLine();
-		if (ImGui::SmallButton("Expand"))
-			SetAllNodesExpanded(rootNodes, true);
-
-		ImGui::SameLine();
-		ImGui::TextDisabled("| %zu", rootNodes.size());
-
-		ImGui::SameLine();
+		if (ImGui::BeginTabBar("HierarchyTabs"))
 		{
-			const bool pickerActive = Config::settings.inspector.objectPickerEnabled;
-			if (pickerActive)
+			if (ImGui::BeginTabItem("Scene"))
 			{
-				ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.8f, 0.2f, 0.2f, 1.0f));
-				ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 0.3f, 0.3f, 1.0f));
-				ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.7f, 0.15f, 0.15f, 1.0f));
-			}
-			if (ImGui::SmallButton(pickerActive ? "Pick: ON" : "Pick"))
-				Config::settings.inspector.objectPickerEnabled = !Config::settings.inspector.objectPickerEnabled;
-			if (pickerActive)
-				ImGui::PopStyleColor(3);
-		}
-
-		ImGui::PushItemWidth(-1);
-		ImGui::InputTextWithHint("##Search", "Search...", searchBuffer, sizeof(searchBuffer),
-			ImGuiInputTextFlags_EscapeClearsAll);
-		ImGui::PopItemWidth();
-
-		ImGui::Separator();
-
-		if (ImGui::BeginChild("HierarchyTree", ImVec2(0, 0), false))
-		{
-			if (rootNodes.empty())
-			{
-				ImGui::Spacing();
-				ImGui::Spacing();
-				ImGui::NewLine();
-				float cx = (ImGui::GetContentRegionAvail().x - 180.0f) * 0.5f;
-				if (cx > 0.0f) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + cx);
-				ImGui::TextDisabled("No scene hierarchy loaded");
-				ImGui::Spacing();
-				if (cx > 0.0f) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + cx);
-				if (ImGui::Button("Load Scene Hierarchy", ImVec2(180, 0)))
+				if (ImGui::Button("Refresh"))
 					RefreshHierarchy();
-			}
-			else
-			{
-				for (auto& node : rootNodes)
+
+				ImGui::SameLine();
+				ImGui::Checkbox("Auto", &Config::settings.inspector.autoRefresh);
+
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Collapse"))
+					SetAllNodesExpanded(rootNodes, false);
+
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Expand"))
+					SetAllNodesExpanded(rootNodes, true);
+
+				ImGui::SameLine();
+				ImGui::TextDisabled("| %zu", rootNodes.size());
+
+				ImGui::SameLine();
 				{
-					RenderHierarchyNode(node);
+					const bool pickerActive = Config::settings.inspector.objectPickerEnabled;
+					if (pickerActive)
+					{
+						ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.8f, 0.2f, 0.2f, 1.0f));
+						ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 0.3f, 0.3f, 1.0f));
+						ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.7f, 0.15f, 0.15f, 1.0f));
+					}
+					if (ImGui::SmallButton(pickerActive ? "Pick: ON" : "Pick"))
+						Config::settings.inspector.objectPickerEnabled = !Config::settings.inspector.objectPickerEnabled;
+					if (pickerActive)
+						ImGui::PopStyleColor(3);
 				}
+
+				ImGui::PushItemWidth(-1);
+				ImGui::InputTextWithHint("##Search", "Search...", searchBuffer, sizeof(searchBuffer),
+					ImGuiInputTextFlags_EscapeClearsAll);
+				ImGui::PopItemWidth();
+
+				ImGui::Separator();
+
+				if (ImGui::BeginChild("HierarchyTree", ImVec2(0, 0), false))
+				{
+					if (rootNodes.empty())
+					{
+						ImGui::Spacing();
+						ImGui::Spacing();
+						ImGui::NewLine();
+						float cx = (ImGui::GetContentRegionAvail().x - 180.0f) * 0.5f;
+						if (cx > 0.0f) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + cx);
+						ImGui::TextDisabled("No scene hierarchy loaded");
+						ImGui::Spacing();
+						if (cx > 0.0f) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + cx);
+						if (ImGui::Button("Load Scene Hierarchy", ImVec2(180, 0)))
+							RefreshHierarchy();
+					}
+					else
+					{
+						for (auto& node : rootNodes)
+						{
+							RenderHierarchyNode(node);
+						}
+					}
+				}
+				ImGui::EndChild();
+				ImGui::EndTabItem();
 			}
+
+			if (ImGui::BeginTabItem("Static Instances"))
+			{
+				if (ImGui::Button("Refresh"))
+					ScanStaticClasses();
+
+				ImGui::SameLine();
+				ImGui::Checkbox("Auto", &Config::settings.inspector.autoRefresh);
+
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Collapse")) {}
+
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Expand")) {}
+
+				ImGui::SameLine();
+				ImGui::TextDisabled("| %zu", staticInstances.size());
+
+				ImGui::SameLine();
+				ImGui::PushItemWidth(-1);
+				ImGui::InputTextWithHint("##StaticSearch", "Search instances...", staticSearchBuffer, sizeof(staticSearchBuffer), ImGuiInputTextFlags_EscapeClearsAll);
+				ImGui::PopItemWidth();
+
+				ImGui::Separator();
+
+				if (ImGui::BeginChild("StaticInstanceTree", ImVec2(0, 0), false))
+				{
+					if (!hasScannedStatic)
+					{
+						ImGui::Spacing();
+						ImGui::TextDisabled("Click Refresh to scan for custom static instances.");
+					}
+					else if (staticInstances.empty())
+					{
+						ImGui::TextDisabled("No non-null static instances found.");
+					}
+					else
+					{
+						for (const auto& node : staticInstances)
+						{
+							if (staticSearchBuffer[0] != '\0')
+							{
+								std::string lowerFullName = node.fullName;
+								std::string lowerSearch = staticSearchBuffer;
+								std::ranges::transform(lowerFullName, lowerFullName.begin(), ::tolower);
+								std::ranges::transform(lowerSearch, lowerSearch.begin(), ::tolower);
+
+								if (lowerFullName.find(lowerSearch) == std::string::npos)
+									continue;
+							}
+
+							if (ImGui::Selectable(node.fullName.c_str()))
+							{
+								OpenStaticInstanceInNewTab(node);
+							}
+						}
+					}
+				}
+				ImGui::EndChild();
+				ImGui::EndTabItem();
+			}
+			ImGui::EndTabBar();
 		}
-		ImGui::EndChild();
 	}
 	ImGui::End();
 
 	RenderDetailsWindow();
 	DrawSelectedObjectBoundingBox();
 	ProcessObjectPicker();
+}
+
+void Inspector::ScanStaticClasses()
+{
+	staticInstances.clear();
+	printf("[ScanStaticClasses] Started\n");
+	
+	for (const auto& assembly : UR::assembly)
+	{
+		if (!assembly) continue;
+		printf("[ScanStaticClasses] Assembly: %s\n", assembly->name.c_str());
+		
+		for (const auto& klass : assembly->classes)
+		{
+			if (!klass) continue;
+			
+			for (const auto& field : klass->fields) {
+				try {
+					if (field && field->static_field) {
+						if (!field->type) continue;
+						
+						// Mono JIT will abort() if mono_class_vtable is called on an uninflated generic type.
+						// Skip generic types (backtick) and compiler-generated types (<, $).
+						if (klass->name.find('`') != std::string::npos || 
+							klass->name.find('<') != std::string::npos || 
+							klass->name.find('$') != std::string::npos)
+							continue;
+						
+						std::string typeName = field->type->name;
+						if (typeName.starts_with("System.") || typeName.starts_with("UnityEngine.") || typeName.starts_with("Unity."))
+							continue;
+						
+						if (typeName == "int" || typeName == "float" || typeName == "bool" || typeName == "double" || typeName == "string")
+							continue;
+
+						void* instance = nullptr;
+						
+						if (Config::state.unityMode == UnityResolve::Mode::Il2Cpp)
+						{
+							void* static_fields_ptr = *(void**)((uintptr_t)klass->address + 0xB8);
+							if (static_fields_ptr) {
+								instance = *(void**)((uintptr_t)static_fields_ptr + field->offset);
+							}
+						}
+						else 
+						{
+							if (!Helper::SafeGetStaticFieldPointer(field->address, instance)) {
+								instance = nullptr;
+							}
+						}
+
+						if (instance != nullptr)
+						{
+							void* typeClassHandle = Helper::SafeGetObjectClass(instance);
+							if (!typeClassHandle) continue;
+							
+							StaticInstanceNode node;
+							node.instance = instance;
+							node.typeClassHandle = typeClassHandle;
+							
+							std::string kName = klass->namespaze.empty() ? klass->name : klass->namespaze + "." + klass->name;
+							node.name = kName + "." + field->name;
+							node.fullName = node.name + " (" + typeName + ")";
+							staticInstances.push_back(std::move(node));
+						}
+					}
+				} catch(...) {
+				}
+			}
+		}
+	}
+	
+	std::ranges::sort(staticInstances, [](const auto& a, const auto& b) {
+		return a.fullName < b.fullName;
+	});
+	
+	hasScannedStatic = true;
+	printf("[ScanStaticClasses] Finished. Found %zu instances.\n", staticInstances.size());
+}
+
+void Inspector::OpenStaticInstanceInNewTab(const StaticInstanceNode& node)
+{
+	if (openTabs.size() >= maxTabs) return;
+
+	InspectedObjectTab newTab;
+	newTab.gameObject = nullptr; 
+	newTab.tabName = "[S] " + node.name;
+	
+	InspectionTarget rootTarget;
+	rootTarget.gameObject = nullptr;
+	rootTarget.instance = node.instance;
+	rootTarget.classHandle = node.typeClassHandle;
+	rootTarget.name = node.name;
+	
+	rootTarget.cachedComponents.push_back(reinterpret_cast<UT::Component*>(node.instance));
+	rootTarget.cachedComponentNames.push_back(node.fullName);
+	
+	rootTarget.cachedComponentFields.push_back(GetObjectFields(node.instance, node.typeClassHandle));
+	rootTarget.cachedComponentProperties.push_back(GetObjectProperties(node.instance, node.typeClassHandle));
+	rootTarget.cachedComponentMethods.push_back(GetObjectMethods(node.instance, node.typeClassHandle));
+	
+	newTab.navigationStack.push_back(std::move(rootTarget));
+
+	openTabs.push_back(std::move(newTab));
+	activeTabIndex = static_cast<int>(openTabs.size()) - 1;
+	showDetailsWindow = true;
 }

--- a/UnityInspector/src/features/inspector/inspector.h
+++ b/UnityInspector/src/features/inspector/inspector.h
@@ -45,6 +45,14 @@ struct HierarchyNode final
 	bool pendingExpandValue = false;
 };
 
+struct StaticInstanceNode
+{
+	void* instance = nullptr;
+	void* typeClassHandle = nullptr;
+	std::string fullName;
+	std::string name;
+};
+
 struct InspectionTarget
 {
 	UT::GameObject* gameObject = nullptr;
@@ -92,6 +100,10 @@ private:
 	std::vector<HierarchyNode> rootNodes;
 	char searchBuffer[256] = {};
 
+	std::vector<StaticInstanceNode> staticInstances;
+	char staticSearchBuffer[256] = {};
+	bool hasScannedStatic = false;
+
 	std::vector<InspectedObjectTab> openTabs;
 	int activeTabIndex = -1;
 	static constexpr int maxTabs = 10;
@@ -111,6 +123,8 @@ private:
 	void SetAllNodesExpanded(std::vector<HierarchyNode>& nodes, bool expanded);
 
 	void OpenObjectInNewTab(UT::GameObject* obj);
+	void OpenStaticInstanceInNewTab(const StaticInstanceNode& node);
+	void ScanStaticClasses();
 	void CloseTab(int tabIndex);
 	void SwitchToTab(int tabIndex);
 	InspectedObjectTab* GetActiveTab();

--- a/UnityInspector/src/features/inspector/inspector_window.cpp
+++ b/UnityInspector/src/features/inspector/inspector_window.cpp
@@ -115,9 +115,72 @@ static void SectionLabel(const char* text, size_t count)
 		ImGui::TextDisabled("%s", text);
 }
 
+static std::string SimplifyTypeName(const std::string& typeName)
+{
+	static const std::unordered_map<std::string, std::string> primitiveMap = {
+		{"System.Int32", "int"}, {"System.Single", "float"}, {"System.Boolean", "bool"},
+		{"System.Double", "double"}, {"System.String", "string"}, {"System.Int64", "long"},
+		{"System.Int16", "short"}, {"System.Byte", "byte"}, {"System.UInt32", "uint"},
+		{"System.UInt64", "ulong"}, {"System.UInt16", "ushort"}, {"System.SByte", "sbyte"},
+		{"System.Void", "void"}, {"System.Object", "object"}
+	};
+
+	auto it = primitiveMap.find(typeName);
+	if (it != primitiveMap.end())
+		return it->second;
+
+	std::string result = typeName;
+
+	size_t angleBracketPos = result.find('<');
+	if (angleBracketPos != std::string::npos)
+	{
+		size_t lastAngle = result.rfind('>');
+		if (lastAngle != std::string::npos && lastAngle > angleBracketPos)
+		{
+			std::string outerPart = result.substr(0, angleBracketPos);
+			std::string innerPart = result.substr(angleBracketPos + 1, lastAngle - angleBracketPos - 1);
+
+			std::string simplifiedInner;
+			size_t start = 0;
+			int depth = 0;
+			for (size_t i = 0; i <= innerPart.size(); ++i)
+			{
+				if (i < innerPart.size() && innerPart[i] == '<') ++depth;
+				else if (i < innerPart.size() && innerPart[i] == '>') --depth;
+				else if ((i == innerPart.size() || innerPart[i] == ',') && depth == 0)
+				{
+					std::string token = innerPart.substr(start, i - start);
+					while (!token.empty() && token[0] == ' ') token.erase(token.begin());
+					while (!token.empty() && token.back() == ' ') token.pop_back();
+					if (!simplifiedInner.empty()) simplifiedInner += ", ";
+					simplifiedInner += SimplifyTypeName(token);
+					start = i + 1;
+				}
+			}
+
+			size_t lastDot = outerPart.rfind('.');
+			if (lastDot != std::string::npos)
+				outerPart = outerPart.substr(lastDot + 1);
+
+			size_t backtick = outerPart.find('`');
+			if (backtick != std::string::npos)
+				outerPart = outerPart.substr(0, backtick);
+
+			return outerPart + "<" + simplifiedInner + ">" + result.substr(lastAngle + 1);
+		}
+	}
+
+	size_t lastDot = result.rfind('.');
+	if (lastDot != std::string::npos)
+		return result.substr(lastDot + 1);
+
+	return result;
+}
+
+
 void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& field)
 {
-	if (!instance || field.offset < 0) return;
+	if (!instance) return;
 
 	ImGui::PushID(field.offset);
 
@@ -383,40 +446,124 @@ void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& fi
 			else { ImGui::TextDisabled("ERROR"); }
 			break;
 		}
+		case EditableType::Enum:
+		{
+			int val;
+			if (Helper::SafeReadInt(instance, field.offset, val))
+			{
+				const auto enumVals = GetEnumValues(field.enumTypeName);
+
+				const char* currentName = "Unknown";
+				for (const auto& pair : enumVals)
+				{
+					if (pair.second == val) { currentName = pair.first.c_str(); break; }
+				}
+				
+				ImGui::TextDisabled("%s", currentName);
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Enter"))
+				{
+					if (auto activeTab = GetActiveTab())
+					{
+						void* instancePtr = nullptr;
+						if (field.isValueType)
+							instancePtr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(instance) + field.offset);
+						else
+							Helper::SafeReadPointer(instance, field.offset, instancePtr);
+							
+						if (instancePtr)
+						{
+							InspectionTarget nextTarget;
+							nextTarget.instance = instancePtr;
+							nextTarget.name = field.name;
+							nextTarget.classHandle = field.classHandle;
+							nextTarget.cachedComponents.push_back(reinterpret_cast<UT::Component*>(instancePtr));
+							nextTarget.cachedComponentNames.push_back(field.typeName);
+							void* targetKlass = field.isValueType ? field.typeClassHandle : nullptr;
+							nextTarget.cachedComponentFields.push_back(GetObjectFields(instancePtr, targetKlass));
+							nextTarget.cachedComponentProperties.push_back(GetObjectProperties(instancePtr, targetKlass));
+							nextTarget.cachedComponentMethods.push_back(GetObjectMethods(instancePtr, targetKlass));
+							activeTab->navigationStack.push_back(std::move(nextTarget));
+						}
+					}
+				}
+			}
+			else { ImGui::TextDisabled("ERROR"); }
+			break;
+		}
         case EditableType::CustomObject:
         {
-            ImGui::TextDisabled("(Object)");
-            ImGui::SameLine();
-            if (ImGui::SmallButton("Enter"))
+            bool isNullable = field.typeName.find("System.Nullable") != std::string::npos;
+            if (isNullable && field.isValueType)
             {
-                if (auto activeTab = GetActiveTab())
+                void* nullablePtr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(instance) + field.offset);
+                bool hasValue = false;
+                Helper::SafeReadBool(nullablePtr, 0, hasValue);
+                if (!hasValue)
                 {
-                    void* instancePtr = nullptr;
-                    if (field.isValueType)
+                    ImGui::TextDisabled("null");
+                }
+                else
+                {
+                    ImGui::TextDisabled("Nullable (has value)");
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("Enter"))
                     {
-                        instancePtr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(instance) + field.offset);
+                        if (auto activeTab = GetActiveTab())
+                        {
+                            InspectionTarget nextTarget;
+                            nextTarget.instance = nullablePtr;
+                            nextTarget.name = field.name;
+                            nextTarget.classHandle = field.classHandle;
+                            nextTarget.cachedComponents.push_back(reinterpret_cast<UT::Component*>(nullablePtr));
+                            nextTarget.cachedComponentNames.push_back(field.typeName);
+                            nextTarget.cachedComponentFields.push_back(GetObjectFields(nullablePtr, field.typeClassHandle));
+                            nextTarget.cachedComponentProperties.push_back(GetObjectProperties(nullablePtr, field.typeClassHandle));
+                            nextTarget.cachedComponentMethods.push_back(GetObjectMethods(nullablePtr, field.typeClassHandle));
+                            activeTab->navigationStack.push_back(std::move(nextTarget));
+                        }
                     }
-                    else
+                }
+            }
+            else
+            {
+                void* instancePtr = nullptr;
+                if (field.isValueType)
+                {
+                    instancePtr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(instance) + field.offset);
+                }
+                else
+                {
+                    Helper::SafeReadPointer(instance, field.offset, instancePtr);
+                }
+
+                if (!instancePtr)
+                {
+                    ImGui::TextDisabled("null");
+                }
+                else
+                {
+                    ImGui::TextDisabled("(Object) %p", instancePtr);
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("Enter"))
                     {
-                        Helper::SafeReadPointer(instance, field.offset, instancePtr);
-                    }
+                        if (auto activeTab = GetActiveTab())
+                        {
+                            InspectionTarget nextTarget;
+                            nextTarget.instance = instancePtr;
+                            nextTarget.name = field.name;
+                            nextTarget.classHandle = field.classHandle;
+                            
+                            nextTarget.cachedComponents.push_back(reinterpret_cast<UT::Component*>(instancePtr));
+                            nextTarget.cachedComponentNames.push_back(field.typeName);
+                            void* targetKlass = field.isValueType ? field.typeClassHandle : nullptr;
 
-                    if (instancePtr)
-                    {
-                        InspectionTarget nextTarget;
-                        nextTarget.instance = instancePtr;
-                        nextTarget.name = field.name;
-                        nextTarget.classHandle = field.classHandle;
-                        
-                        nextTarget.cachedComponents.push_back(reinterpret_cast<UT::Component*>(instancePtr));
-                        nextTarget.cachedComponentNames.push_back(field.typeName);
-                        void* targetKlass = field.isValueType ? field.typeClassHandle : nullptr;
+                            nextTarget.cachedComponentFields.push_back(GetObjectFields(instancePtr, targetKlass));
+                            nextTarget.cachedComponentProperties.push_back(GetObjectProperties(instancePtr, targetKlass));
+                            nextTarget.cachedComponentMethods.push_back(GetObjectMethods(instancePtr, targetKlass));
 
-                        nextTarget.cachedComponentFields.push_back(GetObjectFields(instancePtr, targetKlass));
-                        nextTarget.cachedComponentProperties.push_back(GetObjectProperties(instancePtr, targetKlass));
-                        nextTarget.cachedComponentMethods.push_back(GetObjectMethods(instancePtr, targetKlass));
-
-                        activeTab->navigationStack.push_back(std::move(nextTarget));
+                            activeTab->navigationStack.push_back(std::move(nextTarget));
+                        }
                     }
                 }
             }
@@ -754,7 +901,8 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
             
 			bool isArray = field->typeName.find("[]") != std::string::npos;
 			bool isList = field->typeName.find("System.Collections.Generic.List") != std::string::npos;
-			bool isCollection = !field->isStatic && field->editableType == EditableType::None && (isArray || isList);
+			bool isDictionary = field->typeName.find("System.Collections.Generic.Dictionary") != std::string::npos;
+			bool isCollection = !field->isStatic && (isArray || isList || isDictionary);
 
 			bool isExpanded = false;
 			void* collectionPtr = nullptr;
@@ -772,7 +920,7 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
 						collectionCount = static_cast<int>(arr->max_length);
 						arrayDataStart = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(arr) + 0x20);
 					}
-					else
+					else if (isList)
 					{
 						auto list = reinterpret_cast<UT::List<uintptr_t>*>(collectionPtr);
 						collectionCount = list->size;
@@ -780,6 +928,14 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
 						{
 							arrayDataStart = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(list->pList) + 0x20);
 						}
+					}
+					else if (isDictionary)
+					{
+						Helper::SafeReadInt(collectionPtr, 0x20, collectionCount);
+						void* pEntries = nullptr;
+						Helper::SafeReadPointer(collectionPtr, 0x18, pEntries);
+						if (pEntries)
+							arrayDataStart = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(pEntries) + 0x20);
 					}
 					
 					collectionCount = std::max(0, std::min(collectionCount, 1000));
@@ -824,124 +980,146 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
 			}
 
 			ImGui::TableSetColumnIndex(1);
-			ImGui::TextUnformatted(field->typeName.c_str());
+			{
+				std::string shortType = SimplifyTypeName(field->typeName);
+				ImGui::TextUnformatted(shortType.c_str());
+				if (ImGui::IsItemHovered())
+				{
+					ImGui::BeginTooltip();
+					ImGui::Text("%s", field->typeName.c_str());
+					ImGui::EndTooltip();
+				}
+			}
 
 			ImGui::TableSetColumnIndex(2);
 			RenderEditableField(instance, *field);
 
 			ImGui::TableSetColumnIndex(3);
-			if (!field->isStatic && field->editableType == EditableType::None && FieldEditor::IsPointerType(field->typeName))
-			{
-				ImGui::PushID(field->fieldHandle);
-				if (ImGui::SmallButton("Enter"))
-				{
-					if (auto activeTab = GetActiveTab())
-					{
-						void* instancePtr = nullptr;
-						
-						if (field->isValueType)
-						{
-							instancePtr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(instance) + field->offset);
-						}
-						else
-						{
-							Helper::SafeReadPointer(instance, field->offset, instancePtr);
-						}
 
-						if (instancePtr)
-						{
-							InspectionTarget nextTarget;
-							nextTarget.instance = instancePtr;
-							nextTarget.name = field->name;
-							nextTarget.classHandle = field->classHandle;
-							
-							void* targetKlass = field->isValueType ? field->typeClassHandle : nullptr;
-
-							nextTarget.cachedComponents.push_back(reinterpret_cast<UT::Component*>(instancePtr));
-							nextTarget.cachedComponentNames.push_back(field->typeName);
-							nextTarget.cachedComponentFields.push_back(GetObjectFields(instancePtr, targetKlass));
-							nextTarget.cachedComponentProperties.push_back(GetObjectProperties(instancePtr, targetKlass));
-							nextTarget.cachedComponentMethods.push_back(GetObjectMethods(instancePtr, targetKlass));
-
-							activeTab->navigationStack.push_back(std::move(nextTarget));
-						}
-					}
-				}
-				ImGui::PopID();
-			}
 
 			if (isExpanded)
 			{
 				if (arrayDataStart)
 				{
-					std::string elementTypeName = "Element";
-					if (isArray)
+					if (isDictionary)
 					{
-						size_t pos = field->typeName.find("[]");
-						if (pos != std::string::npos) elementTypeName = field->typeName.substr(0, pos);
-					}
-					else if (isList)
-					{
-						size_t start = field->typeName.find("<");
-						size_t end = field->typeName.rfind(">");
-						if (start != std::string::npos && end != std::string::npos && end > start)
+						for (int i = 0; i < collectionCount; ++i)
 						{
-							elementTypeName = field->typeName.substr(start + 1, end - start - 1);
+							ImGui::TableNextRow();
+
+							ImGui::TableSetColumnIndex(0);
+							ImGui::Indent(15.0f);
+							ImGui::Text("[%d]", i);
+							ImGui::Unindent(15.0f);
+
+							void* entryKey = nullptr;
+							void* entryValue = nullptr;
+							Helper::SafeReadPointer(arrayDataStart, i * 24 + 8, entryKey);
+							Helper::SafeReadPointer(arrayDataStart, i * 24 + 16, entryValue);
+
+							ImGui::TableSetColumnIndex(1);
+							ImGui::TextDisabled("Entry");
+
+							ImGui::TableSetColumnIndex(2);
+							ImGui::Text("%p -> %p", entryKey, entryValue);
+
+							ImGui::TableSetColumnIndex(3);
+							if (entryValue)
+							{
+								ImGui::PushID(reinterpret_cast<intptr_t>(arrayDataStart) + i);
+								if (ImGui::SmallButton("Enter"))
+								{
+									if (auto activeTab = GetActiveTab())
+									{
+										InspectionTarget nextTarget;
+										nextTarget.instance = entryValue;
+										nextTarget.name = field->name + "[" + std::to_string(i) + "].Value";
+										nextTarget.classHandle = nullptr;
+
+										nextTarget.cachedComponents.push_back(reinterpret_cast<UT::Component*>(entryValue));
+										nextTarget.cachedComponentNames.push_back("DictionaryValue");
+
+										nextTarget.cachedComponentFields.push_back(GetObjectFields(entryValue, nullptr));
+										nextTarget.cachedComponentProperties.push_back(GetObjectProperties(entryValue, nullptr));
+										nextTarget.cachedComponentMethods.push_back(GetObjectMethods(entryValue, nullptr));
+
+										activeTab->navigationStack.push_back(std::move(nextTarget));
+									}
+								}
+								ImGui::PopID();
+							}
 						}
-					}
-
-					for (int i = 0; i < collectionCount; ++i)
-					{
-						ImGui::TableNextRow();
-						
-						ImGui::TableSetColumnIndex(0);
-						ImGui::Indent(15.0f);
-						ImGui::Text("[%d]", i);
-						ImGui::Unindent(15.0f);
-						
-						ImGui::TableSetColumnIndex(1);
-						ImGui::TextDisabled("%s", elementTypeName.c_str());
-					
-					void* elementPtr = nullptr;
-					Helper::SafeReadPointer(arrayDataStart, i * sizeof(void*), elementPtr);
-
-					ImGui::TableSetColumnIndex(2);
-					if (elementPtr)
-					{
-						ImGui::TextDisabled("0x%p", elementPtr);
 					}
 					else
 					{
-						ImGui::TextDisabled("(null)");
-					}
-
-					ImGui::TableSetColumnIndex(3);
-					if (elementPtr)
-					{
-						ImGui::PushID(reinterpret_cast<intptr_t>(arrayDataStart) + i);
-						if (ImGui::SmallButton("Enter"))
+						std::string elementTypeName = "Element";
+						if (isArray)
 						{
-							if (auto activeTab = GetActiveTab())
+							size_t pos = field->typeName.find("[]");
+							if (pos != std::string::npos) elementTypeName = field->typeName.substr(0, pos);
+						}
+						else if (isList)
+						{
+							size_t start = field->typeName.find("<");
+							size_t end = field->typeName.rfind(">");
+							if (start != std::string::npos && end != std::string::npos && end > start)
 							{
-								InspectionTarget nextTarget;
-								nextTarget.instance = elementPtr;
-								nextTarget.name = field->name + "[" + std::to_string(i) + "]";
-								nextTarget.classHandle = nullptr; 
-								
-								nextTarget.cachedComponents.push_back(reinterpret_cast<UT::Component*>(elementPtr));
-								nextTarget.cachedComponentNames.push_back(elementTypeName);
-
-								nextTarget.cachedComponentFields.push_back(GetObjectFields(elementPtr, nullptr));
-								nextTarget.cachedComponentProperties.push_back(GetObjectProperties(elementPtr, nullptr));
-								nextTarget.cachedComponentMethods.push_back(GetObjectMethods(elementPtr, nullptr));
-
-								activeTab->navigationStack.push_back(std::move(nextTarget));
+								elementTypeName = field->typeName.substr(start + 1, end - start - 1);
 							}
 						}
-						ImGui::PopID();
+
+						std::string shortElemType = SimplifyTypeName(elementTypeName);
+						ComponentFieldInfo elemInfo;
+						elemInfo.typeName = elementTypeName;
+						elemInfo.isStatic = false;
+						elemInfo.editableType = DetermineEditableType(elementTypeName, &elemInfo.enumTypeName);
+						
+						int elemSize = sizeof(void*);
+						elemInfo.isValueType = false;
+						
+						if (elemInfo.editableType == EditableType::Enum || elemInfo.editableType == EditableType::Int) {
+							if (elementTypeName == "System.Int64" || elementTypeName == "System.UInt64") elemSize = 8;
+							else if (elementTypeName == "System.Int16" || elementTypeName == "System.UInt16" || elementTypeName == "System.Char") elemSize = 2;
+							else if (elementTypeName == "System.Byte" || elementTypeName == "System.SByte" || elementTypeName == "System.Boolean") elemSize = 1;
+							else elemSize = 4;
+							elemInfo.isValueType = true;
+						}
+						else if (elemInfo.editableType == EditableType::Float) { elemSize = 4; elemInfo.isValueType = true; }
+						else if (elemInfo.editableType == EditableType::Double) { elemSize = 8; elemInfo.isValueType = true; }
+						else if (elemInfo.editableType == EditableType::Bool) { elemSize = 1; elemInfo.isValueType = true; }
+						else if (elemInfo.editableType == EditableType::Vector2) { elemSize = 8; elemInfo.isValueType = true; }
+						else if (elemInfo.editableType == EditableType::Vector3) { elemSize = 12; elemInfo.isValueType = true; }
+						else if (elemInfo.editableType == EditableType::Vector4 || elemInfo.editableType == EditableType::Quaternion || elemInfo.editableType == EditableType::Color) { elemSize = 16; elemInfo.isValueType = true; }
+
+						for (int i = 0; i < collectionCount; ++i)
+						{
+							ImGui::TableNextRow();
+
+							ImGui::TableSetColumnIndex(0);
+							ImGui::Indent(15.0f);
+							ImGui::Text("[%d]", i);
+							ImGui::Unindent(15.0f);
+
+							ImGui::TableSetColumnIndex(1);
+							ImGui::TextUnformatted(shortElemType.c_str());
+							if (ImGui::IsItemHovered())
+							{
+								ImGui::BeginTooltip();
+								ImGui::Text("%s", elementTypeName.c_str());
+								ImGui::EndTooltip();
+							}
+
+							ImGui::TableSetColumnIndex(2);
+							ImGui::PushID(reinterpret_cast<intptr_t>(arrayDataStart) + i);
+							elemInfo.name = "[" + std::to_string(i) + "]";
+							elemInfo.offset = i * elemSize;
+							RenderEditableField(arrayDataStart, elemInfo);
+							ImGui::PopID();
+
+							ImGui::TableSetColumnIndex(3);
+						}
 					}
 				}
-				} // End of if (arrayDataStart)
 				ImGui::TreePop();
 			}
 		}
@@ -1012,7 +1190,16 @@ void Inspector::RenderPropertiesSection(void* instance, const std::vector<Compon
 				ImGui::PopStyleColor();
 
 			ImGui::TableSetColumnIndex(1);
-			ImGui::TextUnformatted(prop->typeName.c_str());
+			{
+				std::string shortType = SimplifyTypeName(prop->typeName);
+				ImGui::TextUnformatted(shortType.c_str());
+				if (ImGui::IsItemHovered())
+				{
+					ImGui::BeginTooltip();
+					ImGui::Text("%s", prop->typeName.c_str());
+					ImGui::EndTooltip();
+				}
+			}
 
 			ImGui::TableSetColumnIndex(2);
 			RenderEditableProperty(instance, *prop);
@@ -1264,7 +1451,7 @@ void Inspector::RenderTabBar()
 		{
 			auto& tab = openTabs[i];
 
-			if (!Helper::SafeIsAlive(tab.gameObject))
+			if (tab.gameObject && !Helper::SafeIsAlive(tab.gameObject))
 				continue;
 
 			bool tabOpen = true;
@@ -1298,7 +1485,7 @@ void Inspector::RenderTabBar()
 
 void Inspector::RenderTabContent(InspectedObjectTab& tab)
 {
-	if (!Helper::SafeIsAlive(tab.gameObject))
+	if (tab.gameObject && !Helper::SafeIsAlive(tab.gameObject))
 	{
 		ImGui::TextDisabled("Object has been destroyed");
 		ImGui::Spacing();
@@ -1391,6 +1578,16 @@ void Inspector::RenderTabContent(InspectedObjectTab& tab)
 	else if (target.instance)
 	{
 		ImGui::TextDisabled("Inspecting nested object at %p", target.instance);
+		ImGui::Spacing();
+		if (ImGui::BeginChild("Content", ImVec2(0, 0), false))
+		{
+			RenderComponentsSection(target, tab);
+		}
+		ImGui::EndChild();
+	}
+	else if (target.classHandle && !target.instance && !target.gameObject)
+	{
+		ImGui::TextDisabled("Inspecting static class at %p", target.classHandle);
 		ImGui::Spacing();
 		if (ImGui::BeginChild("Content", ImVec2(0, 0), false))
 		{

--- a/UnityInspector/src/helper/helper.cpp
+++ b/UnityInspector/src/helper/helper.cpp
@@ -503,24 +503,45 @@ namespace Helper
 		catch (...) { return false; }
 	}
 
+	bool IsValidReadPtr(void* ptr, size_t size = 8)
+	{
+		if (!ptr) return false;
+		MEMORY_BASIC_INFORMATION mbi;
+		if (VirtualQuery(ptr, &mbi, sizeof(mbi)) == 0) return false;
+		if (mbi.State != MEM_COMMIT) return false;
+		if (mbi.Protect == PAGE_NOACCESS || (mbi.Protect & PAGE_GUARD)) return false;
+		return true;
+	}
+
+	__declspec(noinline) void DoSafeGetStaticFieldPointer(void* fieldHandle, void*& outValue)
+	{
+		// Allocate a large buffer on the stack to prevent buffer overflows if the static field is a large struct (Value Type).
+		// il2cpp_field_static_get_value writes the entire struct into the provided pointer. If it's an object (Reference Type), it writes 8 bytes.
+		alignas(16) char safeBuffer[8192] = { 0 };
+
+		if (Config::state.unityMode == UnityResolve::Mode::Mono)
+		{
+			void* vTable = UR::Invoke<void*, void*, void*>("mono_class_vtable", UR::pDomain,
+				UR::Invoke<void*, void*>("mono_field_get_parent", fieldHandle));
+			UR::Invoke<void, void*, void*, void*>("mono_field_static_get_value", vTable, fieldHandle, safeBuffer);
+		}
+		else
+		{
+			UR::Invoke<void, void*, void*>("il2cpp_field_static_get_value", fieldHandle, safeBuffer);
+		}
+
+		outValue = *(void**)safeBuffer;
+	}
+
 	bool SafeGetStaticFieldPointer(void* fieldHandle, void*& outValue)
 	{
 		if (!fieldHandle) return false;
-		try
+		__try
 		{
-			if (Config::state.unityMode == UnityResolve::Mode::Mono)
-			{
-				void* vTable = UR::Invoke<void*, void*, void*>("mono_class_vtable", UR::pDomain,
-					UR::Invoke<void*, void*>("mono_field_get_parent", fieldHandle));
-				UR::Invoke<void, void*, void*, void**>("mono_field_static_get_value", vTable, fieldHandle, &outValue);
-			}
-			else
-			{
-				UR::Invoke<void, void*, void**>("il2cpp_field_static_get_value", fieldHandle, &outValue);
-			}
+			DoSafeGetStaticFieldPointer(fieldHandle, outValue);
 			return true;
 		}
-		catch (...) { return false; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return false; }
 	}
 
 	__declspec(noinline) void* DoGetObjectClass(void* obj, bool isMono)
@@ -537,7 +558,7 @@ namespace Helper
 
 	void* SafeGetObjectClass(void* obj)
 	{
-		if (!obj) return nullptr;
+		if (!IsValidReadPtr(obj)) return nullptr;
 		__try
 		{
 			return DoGetObjectClass(obj, Config::state.unityMode == UnityResolve::Mode::Mono);

--- a/UnityInspector/src/pch/pch.h
+++ b/UnityInspector/src/pch/pch.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 // Defines
 #define WIN32_LEAN_AND_MEAN
@@ -18,6 +18,7 @@
 #include <utility>
 #include <algorithm>
 #include <unordered_set>
+#include <unordered_map>
 #include <format>
 #include <ranges>
 #include <deque>


### PR DESCRIPTION
- Stripped common namespaces (e.g., System., UnityEngine., System.Collections.Generic.) from type names in the UI for better readability, while preserving the fully-qualified names in hover tooltips.
- Refactored array and list visualizers to display items inline according to their respective value-type sizes, rather than just showing raw pointer offsets.
- Implemented direct rendering for System.Collections.Generic.Dictionary<TKey, TValue>, enabling dynamic entry counts and iterative key-value pointer inspection.
- Added explicit UI handling for Nullable types, displaying "null" for unpopulated fields, and generating direct "Enter" navigation paths for populated ones.
- Added a new tab and tracking system to scan and natively inspect global static class instances independent of the standard GameObject component hierarchy.

<img width="374" height="601" alt="Dofus_DpvH3QIi8Q" src="https://github.com/user-attachments/assets/1aacdb34-cba4-40b6-b89d-ba375abe0869" />
<img width="897" height="696" alt="Dofus_JZACZulAoe" src="https://github.com/user-attachments/assets/0f3ec6f0-6f03-4410-981f-e2152e9997f6" />
