### PR TITLE
fix hotkey toggle not working when menu is hidden

### DIFF
--- a/UnityInspector/src/window/window.cpp
+++ b/UnityInspector/src/window/window.cpp
@@ -169,6 +169,9 @@ namespace Window
 		{
 			ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam);
 
+			if (Input::ProcessMessage(uMsg, wParam))
+				return 2;
+
 			if (ImGui::GetIO().WantCaptureMouse || ImGui::GetIO().WantCaptureMouseUnlessPopupClose)
 			{
 				switch (uMsg)
@@ -191,8 +194,6 @@ namespace Window
 				case WM_NCMOUSELEAVE:
 				case WM_NCMOUSEMOVE:
 					return 2;
-				default:
-					if (Input::ProcessMessage(uMsg, wParam)) return 2;
 				}
 			}
 		}


### PR DESCRIPTION
Move Input::ProcessMessage call outside the WantCaptureMouse guard so VK_INSERT and other hotkeys always work regardless of menu visibility.