### PR TITLE
Extend the inspector to recognize and properly render IL2CPP primitive types that were previously shown as hex pointers or missing entirely

### DIFF
--- a/UnityInspector/src/features/inspector/editable_type.h
+++ b/UnityInspector/src/features/inspector/editable_type.h
@@ -13,6 +13,7 @@ enum class EditableType
     Vector4,
     Quaternion,
     Color,
+    Decimal,
     Enum,
     CustomObject
 };

--- a/UnityInspector/src/features/inspector/field_editor.cpp
+++ b/UnityInspector/src/features/inspector/field_editor.cpp
@@ -113,13 +113,13 @@ EditableType DetermineEditableType(const std::string& typeName, std::string* enu
 		typeName == "System.IntPtr" || typeName == "System.UIntPtr" ||
 		IsUInt64WrappingType(typeName))
 		return EditableType::Int;
-	if (typeName == "System.Single" || typeName == "System.Float")
+	if (typeName == "System.Single")
 		return EditableType::Float;
 	if (typeName == "System.Double")
 		return EditableType::Double;
 	if (typeName == "System.Decimal")
 		return EditableType::Decimal;
-	if (typeName == "System.Boolean" || typeName == "System.Bool")
+	if (typeName == "System.Boolean")
 		return EditableType::Bool;
 	if (typeName == "System.String")
 		return EditableType::String;

--- a/UnityInspector/src/features/inspector/field_editor.cpp
+++ b/UnityInspector/src/features/inspector/field_editor.cpp
@@ -91,6 +91,13 @@ static void CheckAndUpdateEnumType(std::string& typeName, const std::string& fie
 	}
 }
 
+bool IsUInt64WrappingType(const std::string& typeName)
+{
+	std::string lower = typeName;
+	std::ranges::transform(lower, lower.begin(), tolower);
+	return lower.find("gametimestamp") != std::string::npos;
+}
+
 EditableType DetermineEditableType(const std::string& typeName, std::string* enumTypeNameOut)
 {
 	std::string effectiveTypeName = typeName;
@@ -100,13 +107,19 @@ EditableType DetermineEditableType(const std::string& typeName, std::string* enu
 
 	if (typeName == "System.Int16" || typeName == "System.Int32" || typeName == "System.Int64" ||
 		typeName == "System.UInt16" || typeName == "System.UInt32" || typeName == "System.UInt64" ||
-		typeName == "System.Byte" || typeName == "System.SByte" || typeName == "System.Char")
+		typeName == "System.Byte" || typeName == "System.SByte" || typeName == "System.Char" ||
+		typeName == "System.Short" || typeName == "System.UShort" ||
+		typeName == "System.Long" || typeName == "System.ULong" ||
+		typeName == "System.IntPtr" || typeName == "System.UIntPtr" ||
+		IsUInt64WrappingType(typeName))
 		return EditableType::Int;
-	if (typeName == "System.Single")
+	if (typeName == "System.Single" || typeName == "System.Float")
 		return EditableType::Float;
 	if (typeName == "System.Double")
 		return EditableType::Double;
-	if (typeName == "System.Boolean")
+	if (typeName == "System.Decimal")
+		return EditableType::Decimal;
+	if (typeName == "System.Boolean" || typeName == "System.Bool")
 		return EditableType::Bool;
 	if (typeName == "System.String")
 		return EditableType::String;
@@ -346,7 +359,9 @@ void FieldEditor::Render()
 
 bool FieldEditor::IsEditableType(const std::string& typeName)
 {
-	return IsIntegerType(typeName) || IsFloatType(typeName) || IsBoolType(typeName) || IsStringType(typeName);
+	return IsIntegerType(typeName) || IsFloatType(typeName) || IsBoolType(typeName) || IsStringType(typeName) ||
+		typeName == "System.Decimal" ||
+		IsUInt64WrappingType(typeName);
 }
 
 bool FieldEditor::IsIntegerType(const std::string& typeName)
@@ -466,6 +481,50 @@ void FieldEditor::ReadValueFromAddress(void* addr, const std::string& typeName, 
 	{
 		state.intValue = static_cast<long long>(*static_cast<int8_t*>(addr));
 	}
+	else if (typeName == "System.IntPtr")
+	{
+		state.intValue = static_cast<long long>(*static_cast<intptr_t*>(addr));
+	}
+	else if (typeName == "System.UIntPtr")
+	{
+		state.intValue = static_cast<long long>(*static_cast<uintptr_t*>(addr));
+	}
+	else if (IsUInt64WrappingType(typeName))
+	{
+		state.intValue = static_cast<long long>(*static_cast<uint64_t*>(addr));
+	}
+	else if (typeName == "System.Decimal")
+	{
+		auto* parts = static_cast<int32_t*>(addr);
+		const int scale = (parts[0] >> 16) & 0x1F;
+		const bool negative = (parts[0] & 0x80000000) != 0;
+		const int64_t lo = static_cast<uint32_t>(parts[2]);
+		const int64_t mid = static_cast<uint32_t>(parts[3]);
+		const int64_t hi = static_cast<uint32_t>(parts[1]);
+		const double unscaled = static_cast<double>(lo) + static_cast<double>(mid) * 4294967296.0 +
+			static_cast<double>(hi) * 18446744073709551616.0;
+		state.floatValue = static_cast<float>(unscaled / std::pow(10.0, scale) * (negative ? -1.0 : 1.0));
+	}
+	else if (typeName == "UnityEngine.Vector2")
+	{
+		state.floatValue = static_cast<Vec2*>(addr)->x;
+	}
+	else if (typeName == "UnityEngine.Vector3")
+	{
+		state.floatValue = static_cast<Vec3*>(addr)->x;
+	}
+	else if (typeName == "UnityEngine.Vector4")
+	{
+		state.floatValue = static_cast<Vec4*>(addr)->x;
+	}
+	else if (typeName == "UnityEngine.Quaternion")
+	{
+		state.floatValue = static_cast<Quat*>(addr)->x;
+	}
+	else if (typeName == "UnityEngine.Color")
+	{
+		state.floatValue = static_cast<Color*>(addr)->r;
+	}
 	else
 	{
 		state.intValue = *static_cast<int32_t*>(addr);
@@ -518,6 +577,57 @@ void FieldEditor::WriteValueToAddress(void* addr, const std::string& typeName, c
 	{
 		*static_cast<int8_t*>(addr) = static_cast<int8_t>(state.intValue);
 	}
+	else if (typeName == "System.IntPtr")
+	{
+		*static_cast<intptr_t*>(addr) = static_cast<intptr_t>(state.intValue);
+	}
+	else if (typeName == "System.UIntPtr")
+	{
+		*static_cast<uintptr_t*>(addr) = static_cast<uintptr_t>(state.intValue);
+	}
+	else if (IsUInt64WrappingType(typeName))
+	{
+		*static_cast<uint64_t*>(addr) = static_cast<uint64_t>(state.intValue);
+	}
+	else if (typeName == "System.Decimal")
+	{
+		auto* parts = static_cast<int32_t*>(addr);
+		const double value = static_cast<double>(state.floatValue);
+		const int scale = (parts[0] >> 16) & 0x1F;
+		const bool negative = value < 0;
+		const double absValue = negative ? -value : value;
+		const double scaled = absValue * std::pow(10.0, scale);
+		const uint64_t unscaled = static_cast<uint64_t>(scaled);
+		parts[0] = (parts[0] & 0x00FF0000) | (negative ? 0x80000000 : 0);
+		parts[1] = static_cast<int32_t>(unscaled >> 32);
+		parts[2] = static_cast<int32_t>(unscaled & 0xFFFFFFFF);
+		parts[3] = static_cast<int32_t>((unscaled >> 32) >> 32);
+	}
+	else if (typeName == "UnityEngine.Vector2")
+	{
+		auto& v = *static_cast<Vec2*>(addr);
+		v.x = v.y = state.floatValue;
+	}
+	else if (typeName == "UnityEngine.Vector3")
+	{
+		auto& v = *static_cast<Vec3*>(addr);
+		v.x = v.y = v.z = state.floatValue;
+	}
+	else if (typeName == "UnityEngine.Vector4")
+	{
+		auto& v = *static_cast<Vec4*>(addr);
+		v.x = v.y = v.z = v.w = state.floatValue;
+	}
+	else if (typeName == "UnityEngine.Quaternion")
+	{
+		auto& v = *static_cast<Quat*>(addr);
+		v.x = v.y = v.z = v.w = state.floatValue;
+	}
+	else if (typeName == "UnityEngine.Color")
+	{
+		auto& v = *static_cast<Color*>(addr);
+		v.r = v.g = v.b = v.a = state.floatValue;
+	}
 	else
 	{
 		*static_cast<int32_t*>(addr) = state.intValue;
@@ -561,6 +671,50 @@ std::string FieldEditor::FormatFieldValue(void* addr, const std::string& typeNam
 		return std::to_string(*static_cast<uint8_t*>(addr));
 	if (typeName == "System.SByte")
 		return std::to_string(*static_cast<int8_t*>(addr));
+	if (typeName == "System.IntPtr")
+		return std::to_string(*static_cast<intptr_t*>(addr));
+	if (typeName == "System.UIntPtr")
+		return std::to_string(*static_cast<uintptr_t*>(addr));
+	if (IsUInt64WrappingType(typeName))
+		return std::to_string(*static_cast<uint64_t*>(addr));
+	if (typeName == "System.Decimal")
+	{
+		const auto* parts = static_cast<int32_t*>(addr);
+		const int scale = (parts[0] >> 16) & 0x1F;
+		const bool negative = (parts[0] & 0x80000000) != 0;
+		const int64_t lo = static_cast<uint32_t>(parts[2]);
+		const int64_t mid = static_cast<uint32_t>(parts[3]);
+		const int64_t hi = static_cast<uint32_t>(parts[1]);
+		const double unscaled = static_cast<double>(lo) + static_cast<double>(mid) * 4294967296.0 +
+			static_cast<double>(hi) * 18446744073709551616.0;
+		const double value = unscaled / std::pow(10.0, scale) * (negative ? -1.0 : 1.0);
+		return std::format("{:.6f}", value);
+	}
+	if (typeName == "UnityEngine.Vector2")
+	{
+		const auto& v = *static_cast<Vec2*>(addr);
+		return std::format("({:.3f}, {:.3f})", v.x, v.y);
+	}
+	if (typeName == "UnityEngine.Vector3")
+	{
+		const auto& v = *static_cast<Vec3*>(addr);
+		return std::format("({:.3f}, {:.3f}, {:.3f})", v.x, v.y, v.z);
+	}
+	if (typeName == "UnityEngine.Vector4")
+	{
+		const auto& v = *static_cast<Vec4*>(addr);
+		return std::format("({:.3f}, {:.3f}, {:.3f}, {:.3f})", v.x, v.y, v.z, v.w);
+	}
+	if (typeName == "UnityEngine.Quaternion")
+	{
+		const auto& v = *static_cast<Quat*>(addr);
+		return std::format("({:.3f}, {:.3f}, {:.3f}, {:.3f})", v.x, v.y, v.z, v.w);
+	}
+	if (typeName == "UnityEngine.Color")
+	{
+		const auto& v = *static_cast<Color*>(addr);
+		return std::format("RGBA({:.2f}, {:.2f}, {:.2f}, {:.2f})", v.r, v.g, v.b, v.a);
+	}
 	if (IsIntegerType(typeName))
 		return std::to_string(*static_cast<int32_t*>(addr));
 
@@ -618,6 +772,37 @@ void FieldEditor::ReadFieldValue()
 				int8_t val = 0;
 				field->GetStaticValue(&val);
 				state.intValue = static_cast<long long>(val);
+			}
+			else if (typeName == "System.IntPtr")
+			{
+				intptr_t val = 0;
+				field->GetStaticValue(&val);
+				state.intValue = static_cast<long long>(val);
+			}
+			else if (typeName == "System.UIntPtr")
+			{
+				uintptr_t val = 0;
+				field->GetStaticValue(&val);
+				state.intValue = static_cast<long long>(val);
+			}
+			else if (IsUInt64WrappingType(typeName))
+			{
+				uint64_t val = 0;
+				field->GetStaticValue(&val);
+				state.intValue = static_cast<long long>(val);
+			}
+			else if (typeName == "System.Decimal")
+			{
+				int32_t parts[4] = {};
+				field->GetStaticValue(&parts);
+				const int scale = (parts[0] >> 16) & 0x1F;
+				const bool negative = (parts[0] & 0x80000000) != 0;
+				const int64_t lo = static_cast<uint32_t>(parts[2]);
+				const int64_t mid = static_cast<uint32_t>(parts[3]);
+				const int64_t hi = static_cast<uint32_t>(parts[1]);
+				const double unscaled = static_cast<double>(lo) + static_cast<double>(mid) * 4294967296.0 +
+					static_cast<double>(hi) * 18446744073709551616.0;
+				state.floatValue = static_cast<float>(unscaled / std::pow(10.0, scale) * (negative ? -1.0 : 1.0));
 			}
 			else if (typeName == "System.Int16" || typeName == "System.Short")
 			{
@@ -755,6 +940,37 @@ void FieldEditor::WriteFieldValue()
 			{
 				int8_t val = static_cast<int8_t>(state.intValue);
 				field->SetStaticValue(&val);
+			}
+			else if (typeName == "System.IntPtr")
+			{
+				intptr_t val = static_cast<intptr_t>(state.intValue);
+				field->SetStaticValue(&val);
+			}
+			else if (typeName == "System.UIntPtr")
+			{
+				uintptr_t val = static_cast<uintptr_t>(state.intValue);
+				field->SetStaticValue(&val);
+			}
+			else if (IsUInt64WrappingType(typeName))
+			{
+				uint64_t val = static_cast<uint64_t>(state.intValue);
+				field->SetStaticValue(&val);
+			}
+			else if (typeName == "System.Decimal")
+			{
+				int32_t parts[4] = {};
+				field->GetStaticValue(&parts);
+				const int scale = (parts[0] >> 16) & 0x1F;
+				const double value = static_cast<double>(state.floatValue);
+				const bool negative = value < 0;
+				const double absValue = negative ? -value : value;
+				const double scaled = absValue * std::pow(10.0, scale);
+				const uint64_t unscaled = static_cast<uint64_t>(scaled);
+				parts[0] = (parts[0] & 0x00FF0000) | (negative ? 0x80000000 : 0);
+				parts[1] = static_cast<int32_t>(unscaled >> 32);
+				parts[2] = static_cast<int32_t>(unscaled & 0xFFFFFFFF);
+				parts[3] = static_cast<int32_t>((unscaled >> 32) >> 32);
+				field->SetStaticValue(&parts);
 			}
 			else if (typeName == "UnityEngine.Vector2")
 			{

--- a/UnityInspector/src/features/inspector/field_editor.cpp
+++ b/UnityInspector/src/features/inspector/field_editor.cpp
@@ -483,7 +483,7 @@ void FieldEditor::ReadValueFromAddress(void* addr, const std::string& typeName, 
 	}
 	else if (typeName == "System.IntPtr")
 	{
-		state.intValue = static_cast<long long>(*static_cast<intptr_t*>(addr));
+		state.intValue = *static_cast<intptr_t*>(addr);
 	}
 	else if (typeName == "System.UIntPtr")
 	{
@@ -592,7 +592,7 @@ void FieldEditor::WriteValueToAddress(void* addr, const std::string& typeName, c
 	else if (typeName == "System.Decimal")
 	{
 		auto* parts = static_cast<int32_t*>(addr);
-		const double value = static_cast<double>(state.floatValue);
+		const double value = state.floatValue;
 		const int scale = (parts[0] >> 16) & 0x1F;
 		const bool negative = value < 0;
 		const double absValue = negative ? -value : value;
@@ -777,7 +777,7 @@ void FieldEditor::ReadFieldValue()
 			{
 				intptr_t val = 0;
 				field->GetStaticValue(&val);
-				state.intValue = static_cast<long long>(val);
+				state.intValue = val;
 			}
 			else if (typeName == "System.UIntPtr")
 			{
@@ -943,7 +943,7 @@ void FieldEditor::WriteFieldValue()
 			}
 			else if (typeName == "System.IntPtr")
 			{
-				intptr_t val = static_cast<intptr_t>(state.intValue);
+				intptr_t val = state.intValue;
 				field->SetStaticValue(&val);
 			}
 			else if (typeName == "System.UIntPtr")
@@ -961,7 +961,7 @@ void FieldEditor::WriteFieldValue()
 				int32_t parts[4] = {};
 				field->GetStaticValue(&parts);
 				const int scale = (parts[0] >> 16) & 0x1F;
-				const double value = static_cast<double>(state.floatValue);
+				const double value = state.floatValue;
 				const bool negative = value < 0;
 				const double absValue = negative ? -value : value;
 				const double scaled = absValue * std::pow(10.0, scale);

--- a/UnityInspector/src/features/inspector/field_editor.h
+++ b/UnityInspector/src/features/inspector/field_editor.h
@@ -6,6 +6,8 @@ EditableType DetermineEditableType(const std::string& typeName, std::string* enu
 
 std::vector<std::pair<std::string, int>> GetEnumValues(const std::string& enumTypeName);
 
+bool IsUInt64WrappingType(const std::string& typeName);
+
 struct ComponentFieldInfo final
 {
 	std::string name;

--- a/UnityInspector/src/features/inspector/inspector.h
+++ b/UnityInspector/src/features/inspector/inspector.h
@@ -134,7 +134,7 @@ private:
 	void ScanStaticClasses();
 	void CloseTab(int tabIndex);
 	void SwitchToTab(int tabIndex);
-	InspectedObjectTab* GetActiveTab();
+	InspectedObjectTab* GetActiveTab() const;
 	int FindTabForObject(const UT::GameObject* obj) const;
 	void AddToRecentSelections(UT::GameObject* obj);
 	void PinObject(UT::GameObject* obj);

--- a/UnityInspector/src/features/inspector/inspector.h
+++ b/UnityInspector/src/features/inspector/inspector.h
@@ -149,7 +149,7 @@ private:
 	void RenderTransformSection(UT::Transform* transform, InspectedObjectTab& tab) const;
 	void RenderComponentsSection(InspectionTarget& target, InspectedObjectTab& tab);
 	void RenderFieldsSection(void* instance, const std::vector<ComponentFieldInfo>& fields, InspectionTarget& target,
-	                         InspectedObjectTab& tab, size_t componentIndex);
+	                         InspectedObjectTab& tab, size_t componentIndex) const;
 	void RenderPropertiesSection(void* instance, const std::vector<ComponentPropertyInfo>& properties,
 	                             InspectionTarget& target, InspectedObjectTab& tab, size_t componentIndex) const;
 	void RenderMethodsSection(void* instance, const std::vector<ComponentMethodInfo>& methods, InspectionTarget& target,
@@ -174,7 +174,7 @@ private:
 	std::vector<ComponentMethodInfo> GetComponentMethods(UT::Component* component) const;
 
 	std::string BuildObjectPath(UT::Transform* transform) const;
-	void RenderEditableField(void* instance, const ComponentFieldInfo& field, float itemWidth = -1.0f);
+	void RenderEditableField(void* instance, const ComponentFieldInfo& field, float itemWidth = -1.0f) const;
 	void RenderEditableProperty(void* instance, const ComponentPropertyInfo& prop) const;
 	void* InvokeMethod(void* instance, const ComponentMethodInfo& method,
 	                   const std::vector<std::string>& paramValues) const;

--- a/UnityInspector/src/features/inspector/inspector.h
+++ b/UnityInspector/src/features/inspector/inspector.h
@@ -33,6 +33,8 @@ struct MethodInvokeState
 	std::vector<std::string> parameterValues;
 	std::string resultText;
 	bool hasResult = false;
+	void* resultPointer = nullptr;
+	EditableType resultEditableType = EditableType::None;
 };
 
 struct HierarchyNode final

--- a/UnityInspector/src/features/inspector/inspector_window.cpp
+++ b/UnityInspector/src/features/inspector/inspector_window.cpp
@@ -196,7 +196,7 @@ static int GetTypeSize(const std::string& typeName)
 	return sizeof(void*);
 }
 
-__declspec(noinline) static bool SafeReadDecimal(void* addr, double& outValue)
+static bool SafeReadDecimal(void* addr, double& outValue)
 {
 	__try
 	{
@@ -292,7 +292,7 @@ static bool ParseDictionaryTypes(const std::string& typeName, std::string& outKe
 	return true;
 }
 
-void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& field, const float itemWidth)
+void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& field, const float itemWidth) const
 {
 	if (!instance && !field.isStatic) return;
 
@@ -437,8 +437,7 @@ void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& fi
 		case EditableType::Decimal:
 			{
 				int32_t parts[4] = {};
-				const bool mono = Config::state.unityMode == UnityResolve::Mode::Mono;
-				if (mono)
+				if (Config::state.unityMode == UnityResolve::Mode::Mono)
 				{
 					void* vTable = UR::Invoke<void*, void*, void*>("mono_class_vtable", UR::pDomain,
 						UR::Invoke<void*, void*>("mono_field_get_parent", field.fieldHandle));
@@ -824,8 +823,7 @@ void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& fi
 		case EditableType::Decimal:
 			{
 				const auto addr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(instance) + field.offset);
-				double value;
-				if (SafeReadDecimal(addr, value))
+				if (double value; SafeReadDecimal(addr, value))
 					ImGui::TextDisabled("%.6f", value);
 				else
 					ImGui::TextDisabled("ERROR");
@@ -1365,8 +1363,7 @@ void Inspector::RenderEditableProperty(void* instance, const ComponentPropertyIn
 		}
 	case EditableType::String:
 		{
-			void* result = nullptr;
-			if (Helper::SafeInvokeGetterPointer(instance, prop.getterHandle, result))
+			if (void* result = nullptr; Helper::SafeInvokeGetterPointer(instance, prop.getterHandle, result))
 			{
 				auto strPtr = static_cast<UT::String*>(result);
 				const std::string currentStr = strPtr ? strPtr->ToString() : "(null)";
@@ -1405,8 +1402,7 @@ void Inspector::RenderEditableProperty(void* instance, const ComponentPropertyIn
 		}
 	case EditableType::CustomObject:
 		{
-			void* result = nullptr;
-			if (Helper::SafeInvokeGetterPointer(instance, prop.getterHandle, result))
+			if (void* result = nullptr; Helper::SafeInvokeGetterPointer(instance, prop.getterHandle, result))
 			{
 				if (!result)
 					ImGui::TextDisabled("null");
@@ -1540,7 +1536,7 @@ void Inspector::RenderTransformSection(UT::Transform* transform, InspectedObject
 }
 
 void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentFieldInfo>& fields,
-                                    InspectionTarget& target, InspectedObjectTab& tab, const size_t componentIndex)
+                                    InspectionTarget& target, InspectedObjectTab& tab, const size_t componentIndex) const
 {
 	if (fields.empty())
 	{
@@ -1570,7 +1566,7 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
 			filteredFields.push_back(&field);
 	}
 
-	std::sort(filteredFields.begin(), filteredFields.end(), [](const ComponentFieldInfo* a, const ComponentFieldInfo* b) {
+	std::ranges::sort(filteredFields, [](const ComponentFieldInfo* a, const ComponentFieldInfo* b) {
 		if (a->isStatic != b->isStatic) return a->isStatic < b->isStatic;
 		if (!a->isStatic) return a->offset < b->offset;
 		return a->name < b->name;

--- a/UnityInspector/src/features/inspector/inspector_window.cpp
+++ b/UnityInspector/src/features/inspector/inspector_window.cpp
@@ -125,7 +125,8 @@ static std::string SimplifyTypeName(const std::string& typeName)
 		{"System.Double", "double"}, {"System.String", "string"}, {"System.Int64", "long"},
 		{"System.Int16", "short"}, {"System.Byte", "byte"}, {"System.UInt32", "uint"},
 		{"System.UInt64", "ulong"}, {"System.UInt16", "ushort"}, {"System.SByte", "sbyte"},
-		{"System.Char", "char"}, {"System.Void", "void"}, {"System.Object", "object"}
+		{"System.Char", "char"}, {"System.Void", "void"}, {"System.Object", "object"},
+		{"System.Decimal", "decimal"}, {"System.IntPtr", "IntPtr"}, {"System.UIntPtr", "UIntPtr"}
 	};
 
 	if (auto it = primitiveMap.find(typeName); it != primitiveMap.end())
@@ -185,11 +186,35 @@ static int GetTypeSize(const std::string& typeName)
 	if (typeName == "System.Int16" || typeName == "System.UInt16" || typeName == "System.Char") return 2;
 	if (typeName == "System.Int32" || typeName == "System.UInt32" || typeName == "System.Single") return 4;
 	if (typeName == "System.Int64" || typeName == "System.UInt64" || typeName == "System.Double") return 8;
+	if (typeName == "System.Decimal") return 16;
+	if (typeName == "System.IntPtr" || typeName == "System.UIntPtr") return sizeof(void*);
 	if (typeName == "UnityEngine.Vector2") return 8;
 	if (typeName == "UnityEngine.Vector3") return 12;
 	if (typeName == "UnityEngine.Vector4" || typeName == "UnityEngine.Quaternion" || typeName == "UnityEngine.Color")
 		return 16;
+	if (IsUInt64WrappingType(typeName)) return 8;
 	return sizeof(void*);
+}
+
+__declspec(noinline) static bool SafeReadDecimal(void* addr, double& outValue)
+{
+	__try
+	{
+		const auto* parts = static_cast<int32_t*>(addr);
+		const int scale = (parts[0] >> 16) & 0x1F;
+		const bool negative = (parts[0] & 0x80000000) != 0;
+		const int64_t lo = static_cast<uint32_t>(parts[2]);
+		const int64_t mid = static_cast<uint32_t>(parts[3]);
+		const int64_t hi = static_cast<uint32_t>(parts[1]);
+		const double unscaled = static_cast<double>(lo) + static_cast<double>(mid) * 4294967296.0 +
+			static_cast<double>(hi) * 18446744073709551616.0;
+		outValue = unscaled / std::pow(10.0, scale) * (negative ? -1.0 : 1.0);
+		return true;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER)
+	{
+		return false;
+	}
 }
 
 static int GetTypeAlignment(const std::string& typeName)
@@ -198,16 +223,21 @@ static int GetTypeAlignment(const std::string& typeName)
 	if (typeName == "System.Int16" || typeName == "System.UInt16" || typeName == "System.Char") return 2;
 	if (typeName == "System.Int32" || typeName == "System.UInt32" || typeName == "System.Single") return 4;
 	if (typeName == "System.Int64" || typeName == "System.UInt64" || typeName == "System.Double") return 8;
+	if (typeName == "System.Decimal") return 8;
+	if (typeName == "System.IntPtr" || typeName == "System.UIntPtr") return sizeof(void*);
 	if (typeName == "UnityEngine.Vector2") return 4;
 	if (typeName == "UnityEngine.Vector3") return 4;
 	if (typeName == "UnityEngine.Vector4" || typeName == "UnityEngine.Quaternion" || typeName == "UnityEngine.Color")
 		return 4;
+	if (IsUInt64WrappingType(typeName)) return 8;
 	return sizeof(void*);
 }
 
 static bool IsDefinitelyValueType(const std::string& typeName)
 {
 	if (typeName == "System.String" || typeName == "System.Object") return false;
+	if (typeName == "System.Decimal") return true;
+	if (IsUInt64WrappingType(typeName)) return true;
 	if (typeName.starts_with("System.")) return true;
 	if (typeName.starts_with("UnityEngine.Vector") || typeName == "UnityEngine.Quaternion" || typeName ==
 		"UnityEngine.Color")
@@ -354,6 +384,33 @@ void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& fi
 					}
 					else { ImGui::TextDisabled("ERROR"); }
 				}
+				else if (field.typeName == "System.IntPtr")
+				{
+					if (int64_t val; Helper::SafeGetStaticFieldInt64(field.fieldHandle, val))
+					{
+						if (ImGui::InputScalar("##val", ImGuiDataType_S64, &val))
+							Helper::SafeSetStaticFieldInt64(field.fieldHandle, val);
+					}
+					else { ImGui::TextDisabled("ERROR"); }
+				}
+				else if (field.typeName == "System.UIntPtr")
+				{
+					if (uint64_t val; Helper::SafeGetStaticFieldUInt64(field.fieldHandle, val))
+					{
+						if (ImGui::InputScalar("##val", ImGuiDataType_U64, &val))
+							Helper::SafeSetStaticFieldUInt64(field.fieldHandle, val);
+					}
+					else { ImGui::TextDisabled("ERROR"); }
+				}
+				else if (IsUInt64WrappingType(field.typeName))
+				{
+					if (uint64_t val; Helper::SafeGetStaticFieldUInt64(field.fieldHandle, val))
+					{
+						if (ImGui::InputScalar("##val", ImGuiDataType_U64, &val))
+							Helper::SafeSetStaticFieldUInt64(field.fieldHandle, val);
+					}
+					else { ImGui::TextDisabled("ERROR"); }
+				}
 				else
 				{
 					int val;
@@ -376,6 +433,31 @@ void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& fi
 				}
 			else { ImGui::TextDisabled("ERROR"); }
 			break;
+			}
+		case EditableType::Decimal:
+			{
+				int32_t parts[4] = {};
+				const bool mono = Config::state.unityMode == UnityResolve::Mode::Mono;
+				if (mono)
+				{
+					void* vTable = UR::Invoke<void*, void*, void*>("mono_class_vtable", UR::pDomain,
+						UR::Invoke<void*, void*>("mono_field_get_parent", field.fieldHandle));
+					UR::Invoke<void, void*, void*, void*>("mono_field_static_get_value", vTable, field.fieldHandle, &parts);
+				}
+				else
+				{
+					UR::Invoke<void, void*, void*>("il2cpp_field_static_get_value", field.fieldHandle, &parts);
+				}
+				const int scale = (parts[0] >> 16) & 0x1F;
+				const bool negative = (parts[0] & 0x80000000) != 0;
+				const int64_t lo = static_cast<uint32_t>(parts[2]);
+				const int64_t mid = static_cast<uint32_t>(parts[3]);
+				const int64_t hi = static_cast<uint32_t>(parts[1]);
+				const double unscaled = static_cast<double>(lo) + static_cast<double>(mid) * 4294967296.0 +
+					static_cast<double>(hi) * 18446744073709551616.0;
+				const double value = unscaled / std::pow(10.0, scale) * (negative ? -1.0 : 1.0);
+				ImGui::TextDisabled("[Decimal] %.6f", value);
+				break;
 			}
 		case EditableType::Vector2:
 			{
@@ -654,6 +736,33 @@ void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& fi
 					}
 					else { ImGui::TextDisabled("ERROR"); }
 				}
+				else if (field.typeName == "System.IntPtr")
+				{
+					if (int64_t val; Helper::SafeReadInt64(instance, field.offset, val))
+					{
+						if (ImGui::InputScalar("##val", ImGuiDataType_S64, &val))
+							Helper::SafeWriteInt64(instance, field.offset, val);
+					}
+					else { ImGui::TextDisabled("ERROR"); }
+				}
+				else if (field.typeName == "System.UIntPtr")
+				{
+					if (uint64_t val; Helper::SafeReadUInt64(instance, field.offset, val))
+					{
+						if (ImGui::InputScalar("##val", ImGuiDataType_U64, &val))
+							Helper::SafeWriteUInt64(instance, field.offset, val);
+					}
+					else { ImGui::TextDisabled("ERROR"); }
+				}
+				else if (IsUInt64WrappingType(field.typeName))
+				{
+					if (uint64_t val; Helper::SafeReadUInt64(instance, field.offset, val))
+					{
+						if (ImGui::InputScalar("##val", ImGuiDataType_U64, &val))
+							Helper::SafeWriteUInt64(instance, field.offset, val);
+					}
+					else { ImGui::TextDisabled("ERROR"); }
+				}
 				else
 				{
 					int val;
@@ -710,6 +819,16 @@ void Inspector::RenderEditableField(void* instance, const ComponentFieldInfo& fi
 						Helper::SafeWriteDouble(instance, field.offset, fVal);
 				}
 				else { ImGui::TextDisabled("ERROR"); }
+				break;
+			}
+		case EditableType::Decimal:
+			{
+				const auto addr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(instance) + field.offset);
+				double value;
+				if (SafeReadDecimal(addr, value))
+					ImGui::TextDisabled("%.6f", value);
+				else
+					ImGui::TextDisabled("ERROR");
 				break;
 			}
 		case EditableType::Bool:
@@ -1256,6 +1375,67 @@ void Inspector::RenderEditableProperty(void* instance, const ComponentPropertyIn
 			else { ImGui::TextDisabled("ERROR"); }
 			break;
 		}
+	case EditableType::Decimal:
+		{
+			int32_t parts[4] = {};
+			if (Helper::SafeInvokeGetter(instance, prop.getterHandle, &parts, sizeof(parts)))
+			{
+				const int scale = (parts[0] >> 16) & 0x1F;
+				const bool negative = (parts[0] & 0x80000000) != 0;
+				const int64_t lo = static_cast<uint32_t>(parts[2]);
+				const int64_t mid = static_cast<uint32_t>(parts[3]);
+				const int64_t hi = static_cast<uint32_t>(parts[1]);
+				const double unscaled = static_cast<double>(lo) + static_cast<double>(mid) * 4294967296.0 +
+					static_cast<double>(hi) * 18446744073709551616.0;
+				const double value = unscaled / std::pow(10.0, scale) * (negative ? -1.0 : 1.0);
+				ImGui::TextDisabled("%.6f", value);
+			}
+			else { ImGui::TextDisabled("ERROR"); }
+			break;
+		}
+	case EditableType::Enum:
+		{
+			int val = 0;
+			if (Helper::SafeInvokeGetter(instance, prop.getterHandle, &val, sizeof(int)))
+			{
+				ImGui::TextDisabled("%d", val);
+			}
+			else { ImGui::TextDisabled("ERROR"); }
+			break;
+		}
+	case EditableType::CustomObject:
+		{
+			void* result = nullptr;
+			if (Helper::SafeInvokeGetterPointer(instance, prop.getterHandle, result))
+			{
+				if (!result)
+					ImGui::TextDisabled("null");
+				else
+				{
+					ImGui::TextDisabled("(Object) %p", result);
+					ImGui::SameLine();
+					if (ImGui::SmallButton("Enter"))
+					{
+						if (auto activeTab = GetActiveTab())
+						{
+							void* klass = Helper::SafeGetObjectClass(result);
+							InspectionTarget nextTarget;
+							nextTarget.instance = result;
+							nextTarget.name = prop.name;
+							nextTarget.classHandle = klass;
+							nextTarget.cachedComponents.push_back(static_cast<UT::Component*>(result));
+							nextTarget.cachedComponentNames.push_back(prop.typeName);
+							nextTarget.cachedComponentFields.push_back(GetObjectFields(result, klass));
+							nextTarget.cachedComponentProperties.push_back(GetObjectProperties(result, klass));
+							nextTarget.cachedComponentMethods.push_back(GetObjectMethods(result, klass));
+							activeTab->navigationStack.push_back(std::move(nextTarget));
+						}
+					}
+				}
+			}
+			else { ImGui::TextDisabled("ERROR"); }
+			break;
+		}
 	default:
 		ImGui::TextDisabled("...");
 		break;
@@ -1752,7 +1932,9 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
 
 						if (elemInfo.editableType == EditableType::Enum || elemInfo.editableType == EditableType::Int)
 						{
-							if (elementTypeName == "System.Int64" || elementTypeName == "System.UInt64") elemSize = 8;
+							if (elementTypeName == "System.Int64" || elementTypeName == "System.UInt64" ||
+								elementTypeName == "System.IntPtr" || elementTypeName == "System.UIntPtr")
+								elemSize = sizeof(void*);
 							else if (elementTypeName == "System.Int16" || elementTypeName == "System.UInt16" ||
 								elementTypeName == "System.Char")
 								elemSize = 2;
@@ -1770,6 +1952,11 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
 						else if (elemInfo.editableType == EditableType::Double)
 						{
 							elemSize = 8;
+							elemInfo.isValueType = true;
+						}
+						else if (elemInfo.editableType == EditableType::Decimal)
+						{
+							elemSize = 16;
 							elemInfo.isValueType = true;
 						}
 						else if (elemInfo.editableType == EditableType::Bool)
@@ -1873,7 +2060,9 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
 
 						if (elemInfo.editableType == EditableType::Enum || elemInfo.editableType == EditableType::Int)
 						{
-							if (elementTypeName == "System.Int64" || elementTypeName == "System.UInt64") elemSize = 8;
+							if (elementTypeName == "System.Int64" || elementTypeName == "System.UInt64" ||
+								elementTypeName == "System.IntPtr" || elementTypeName == "System.UIntPtr")
+								elemSize = sizeof(void*);
 							else if (elementTypeName == "System.Int16" || elementTypeName == "System.UInt16" ||
 								elementTypeName == "System.Char")
 								elemSize = 2;
@@ -1891,6 +2080,11 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
 						else if (elemInfo.editableType == EditableType::Double)
 						{
 							elemSize = 8;
+							elemInfo.isValueType = true;
+						}
+						else if (elemInfo.editableType == EditableType::Decimal)
+						{
+							elemSize = 16;
 							elemInfo.isValueType = true;
 						}
 						else if (elemInfo.editableType == EditableType::Bool)

--- a/UnityInspector/src/features/inspector/inspector_window.cpp
+++ b/UnityInspector/src/features/inspector/inspector_window.cpp
@@ -1390,6 +1390,12 @@ void Inspector::RenderFieldsSection(void* instance, const std::vector<ComponentF
 			filteredFields.push_back(&field);
 	}
 
+	std::sort(filteredFields.begin(), filteredFields.end(), [](const ComponentFieldInfo* a, const ComponentFieldInfo* b) {
+		if (a->isStatic != b->isStatic) return a->isStatic < b->isStatic;
+		if (!a->isStatic) return a->offset < b->offset;
+		return a->name < b->name;
+	});
+
 	if (filteredFields.empty())
 	{
 		ImGui::TextDisabled("No fields match filters");

--- a/UnityInspector/src/features/inspector/invoke_popup.cpp
+++ b/UnityInspector/src/features/inspector/invoke_popup.cpp
@@ -51,6 +51,7 @@ void Inspector::RenderMethodInvokePopup()
 				case EditableType::Int:
 				case EditableType::Float:
 				case EditableType::Double:
+				case EditableType::Decimal:
 					if (ImGui::InputText("##param", buf, sizeof(buf), ImGuiInputTextFlags_CharsDecimal))
 					{
 						invokeState.parameterValues[i] = buf;
@@ -62,6 +63,36 @@ void Inspector::RenderMethodInvokePopup()
 						if (ImGui::Checkbox("##param", &val))
 						{
 							invokeState.parameterValues[i] = val ? "true" : "false";
+						}
+						break;
+					}
+				case EditableType::Enum:
+					{
+						const std::string& enumTypeName = invokeState.method.parameters[i].second;
+						const auto enumVals = GetEnumValues(enumTypeName);
+						if (!enumVals.empty())
+						{
+							int currentIdx = 0;
+							const int currentVal = std::atoi(invokeState.parameterValues[i].c_str());
+							for (size_t j = 0; j < enumVals.size(); j++)
+							{
+								if (enumVals[j].second == currentVal)
+								{
+									currentIdx = static_cast<int>(j);
+									break;
+								}
+							}
+							std::vector<const char*> names;
+							for (const auto& kv : enumVals) names.push_back(kv.first.c_str());
+							if (ImGui::Combo("##param", &currentIdx, names.data(), static_cast<int>(names.size())))
+							{
+								invokeState.parameterValues[i] = std::to_string(enumVals[currentIdx].second);
+							}
+						}
+						else
+						{
+							if (ImGui::InputText("##param", buf, sizeof(buf)))
+								invokeState.parameterValues[i] = buf;
 						}
 						break;
 					}
@@ -128,8 +159,68 @@ void Inspector::RenderMethodInvokePopup()
 						{
 							invokeState.resultText = "(null)";
 						}
+						break;
 					}
-					break;
+				case EditableType::Decimal:
+					{
+						const auto* parts = static_cast<int32_t*>(unboxed);
+						const int scale = (parts[0] >> 16) & 0x1F;
+						const bool negative = (parts[0] & 0x80000000) != 0;
+						const int64_t lo = static_cast<uint32_t>(parts[2]);
+						const int64_t mid = static_cast<uint32_t>(parts[3]);
+						const int64_t hi = static_cast<uint32_t>(parts[1]);
+						const double unscaled = static_cast<double>(lo) + static_cast<double>(mid) * 4294967296.0 +
+							static_cast<double>(hi) * 18446744073709551616.0;
+						const double value = unscaled / std::pow(10.0, scale) * (negative ? -1.0 : 1.0);
+						invokeState.resultText = std::format("{:.6f}", value);
+						break;
+					}
+				case EditableType::Enum:
+					{
+						const int val = *static_cast<int*>(unboxed);
+						const auto& retTypeName = invokeState.method.returnTypeName;
+						const auto enumVals = GetEnumValues(retTypeName);
+						std::string enumName;
+						for (const auto& [fst, snd] : enumVals)
+						{
+							if (snd == val) { enumName = fst; break; }
+						}
+						if (!enumName.empty())
+							invokeState.resultText = std::format("{} ({})", enumName, val);
+						else
+							invokeState.resultText = std::to_string(val);
+						break;
+					}
+				case EditableType::Vector2:
+					{
+						const auto* v = static_cast<float*>(unboxed);
+						invokeState.resultText = std::format("({:.3f}, {:.3f})", v[0], v[1]);
+						break;
+					}
+				case EditableType::Vector3:
+					{
+						const auto* v = static_cast<float*>(unboxed);
+						invokeState.resultText = std::format("({:.3f}, {:.3f}, {:.3f})", v[0], v[1], v[2]);
+						break;
+					}
+				case EditableType::Vector4:
+					{
+						const auto* v = static_cast<float*>(unboxed);
+						invokeState.resultText = std::format("({:.3f}, {:.3f}, {:.3f}, {:.3f})", v[0], v[1], v[2], v[3]);
+						break;
+					}
+				case EditableType::Quaternion:
+					{
+						const auto* v = static_cast<float*>(unboxed);
+						invokeState.resultText = std::format("({:.3f}, {:.3f}, {:.3f}, {:.3f})", v[0], v[1], v[2], v[3]);
+						break;
+					}
+				case EditableType::Color:
+					{
+						const auto* v = static_cast<float*>(unboxed);
+						invokeState.resultText = std::format("RGBA({:.2f}, {:.2f}, {:.2f}, {:.2f})", v[0], v[1], v[2], v[3]);
+						break;
+					}
 					default:
 							invokeState.resultText = std::format("(object: 0x{:X})",
 							                                     reinterpret_cast<uintptr_t>(result));

--- a/UnityInspector/src/features/inspector/invoke_popup.cpp
+++ b/UnityInspector/src/features/inspector/invoke_popup.cpp
@@ -69,8 +69,7 @@ void Inspector::RenderMethodInvokePopup()
 				case EditableType::Enum:
 					{
 						const std::string& enumTypeName = invokeState.method.parameters[i].second;
-						const auto enumVals = GetEnumValues(enumTypeName);
-						if (!enumVals.empty())
+						if (const auto enumVals = GetEnumValues(enumTypeName); !enumVals.empty())
 						{
 							int currentIdx = 0;
 							const int currentVal = std::atoi(invokeState.parameterValues[i].c_str());
@@ -83,7 +82,7 @@ void Inspector::RenderMethodInvokePopup()
 								}
 							}
 							std::vector<const char*> names;
-							for (const auto& kv : enumVals) names.push_back(kv.first.c_str());
+							for (const auto& key : enumVals | std::views::keys) names.push_back(key.c_str());
 							if (ImGui::Combo("##param", &currentIdx, names.data(), static_cast<int>(names.size())))
 							{
 								invokeState.parameterValues[i] = std::to_string(enumVals[currentIdx].second);

--- a/UnityInspector/src/features/inspector/invoke_popup.cpp
+++ b/UnityInspector/src/features/inspector/invoke_popup.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "inspector.h"
+#include "helper/helper.h"
 
 void Inspector::RenderMethodInvokePopup()
 {
@@ -83,6 +84,8 @@ void Inspector::RenderMethodInvokePopup()
 			void* result = InvokeMethod(invokeState.targetInstance, invokeState.method, invokeState.parameterValues);
 
 			invokeState.hasResult = true;
+			invokeState.resultPointer = nullptr;
+			invokeState.resultEditableType = EditableType::None;
 			if (result)
 			{
 				if (invokeState.method.returnTypeName == "void" || invokeState.method.returnTypeName == "System.Void")
@@ -92,6 +95,8 @@ void Inspector::RenderMethodInvokePopup()
 				else
 				{
 					const EditableType retType = DetermineEditableType(invokeState.method.returnTypeName);
+					invokeState.resultPointer = result;
+					invokeState.resultEditableType = retType;
 					void* unboxed = UR::Invoke<void*, void*>(
 						Config::state.unityMode == UnityResolve::Mode::Mono
 							? "mono_object_unbox"
@@ -160,6 +165,30 @@ void Inspector::RenderMethodInvokePopup()
 		{
 			ImGui::Separator();
 			ImGui::Text("Result: %s", invokeState.resultText.c_str());
+			if (invokeState.resultPointer && invokeState.resultEditableType == EditableType::CustomObject)
+			{
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Enter"))
+				{
+					if (auto activeTab = GetActiveTab())
+					{
+						void* klass = Helper::SafeGetObjectClass(invokeState.resultPointer);
+						InspectionTarget nextTarget;
+						nextTarget.instance = invokeState.resultPointer;
+						nextTarget.name = invokeState.method.name + "()";
+						nextTarget.classHandle = klass;
+
+						nextTarget.cachedComponents.push_back(static_cast<UT::Component*>(invokeState.resultPointer));
+						nextTarget.cachedComponentNames.push_back(invokeState.method.returnTypeName);
+
+						nextTarget.cachedComponentFields.push_back(GetObjectFields(invokeState.resultPointer, klass));
+						nextTarget.cachedComponentProperties.push_back(GetObjectProperties(invokeState.resultPointer, klass));
+						nextTarget.cachedComponentMethods.push_back(GetObjectMethods(invokeState.resultPointer, klass));
+
+						activeTab->navigationStack.push_back(std::move(nextTarget));
+					}
+				}
+			}
 		}
 	}
 	ImGui::End();

--- a/UnityInspector/src/features/inspector/utils.cpp
+++ b/UnityInspector/src/features/inspector/utils.cpp
@@ -601,12 +601,12 @@ void Inspector::SwitchToTab(const int tabIndex)
 	ImGui::SetWindowFocus("Inspector");
 }
 
-InspectedObjectTab* Inspector::GetActiveTab()
+InspectedObjectTab* Inspector::GetActiveTab() const
 {
 	if (activeTabIndex < 0 || std::cmp_greater_equal(activeTabIndex, openTabs.size()))
 		return nullptr;
 
-	return &openTabs[activeTabIndex];
+	return const_cast<InspectedObjectTab*>(&openTabs[activeTabIndex]);
 }
 
 int Inspector::FindTabForObject(const UT::GameObject* obj) const

--- a/UnityInspector/src/helper/helper.cpp
+++ b/UnityInspector/src/helper/helper.cpp
@@ -1355,6 +1355,60 @@ namespace Helper
 					result.buffers.push_back(std::move(buf));
 					break;
 				}
+			case EditableType::Enum:
+				{
+					auto buf = std::make_unique<char[]>(sizeof(int));
+					*reinterpret_cast<int*>(buf.get()) = std::stoi(valueStr);
+					result.params.push_back(buf.get());
+					result.buffers.push_back(std::move(buf));
+					break;
+				}
+			case EditableType::Decimal:
+				{
+					auto buf = std::make_unique<char[]>(16);
+					int32_t parts[4] = {};
+					const double val = std::stod(valueStr);
+					const bool negative = val < 0;
+					const double absVal = negative ? -val : val;
+					const uint64_t scaled = static_cast<uint64_t>(absVal * 1.0);
+					parts[0] = negative ? 0x80000000 : 0;
+					parts[1] = static_cast<int32_t>(scaled >> 32);
+					parts[2] = static_cast<int32_t>(scaled & 0xFFFFFFFF);
+					parts[3] = 0;
+					std::memcpy(buf.get(), parts, 16);
+					result.params.push_back(buf.get());
+					result.buffers.push_back(std::move(buf));
+					break;
+				}
+			case EditableType::Vector2:
+				{
+					auto buf = std::make_unique<char[]>(sizeof(Vec2));
+					auto& v = *reinterpret_cast<Vec2*>(buf.get());
+					v.x = v.y = std::stof(valueStr);
+					result.params.push_back(buf.get());
+					result.buffers.push_back(std::move(buf));
+					break;
+				}
+			case EditableType::Vector3:
+				{
+					auto buf = std::make_unique<char[]>(sizeof(Vec3));
+					auto& v = *reinterpret_cast<Vec3*>(buf.get());
+					v.x = v.y = v.z = std::stof(valueStr);
+					result.params.push_back(buf.get());
+					result.buffers.push_back(std::move(buf));
+					break;
+				}
+			case EditableType::Vector4:
+			case EditableType::Quaternion:
+			case EditableType::Color:
+				{
+					auto buf = std::make_unique<char[]>(16);
+					auto* f = reinterpret_cast<float*>(buf.get());
+					f[0] = f[1] = f[2] = f[3] = std::stof(valueStr);
+					result.params.push_back(buf.get());
+					result.buffers.push_back(std::move(buf));
+					break;
+				}
 			default:
 				result.params.push_back(nullptr);
 				break;


### PR DESCRIPTION
- EditableType enum: add Decimal
- DetermineEditableType: add System.Short, UShort, Long, ULong, Float, Bool, IntPtr,
  UIntPtr, Decimal; add IsUInt64WrappingType for GameTimeStamp and similar timestamp
  value-type wrappers (treated as editable uint64 instead of opaque pointer)
- FormatFieldValue, ReadValueFromAddress, WriteValueFromAddress: handle Decimal,
  IntPtr/UIntPtr, Vector2/3/4, Quaternion, Color (were falling through to hex pointer)
- RenderEditableField (static + instance): add Decimal (read-only display), IntPtr,
  UIntPtr, and GameTimeStamp editors
- RenderEditableProperty: add Enum, Decimal, and CustomObject cases
- RenderMethodInvokePopup: add Enum combo for parameters; Decimal, Enum, Vector2/3/4,
  Quaternion, Color return value display
- BuildInvokeParams: build buffers for Enum, Decimal, Vector2/3/4, Quaternion, Color
- GetTypeSize / GetTypeAlignment / IsDefinitelyValueType / SimplifyTypeName: add
  Decimal, IntPtr/UIntPtr, GameTimeStamp entries
- Collection element sizing: handle Decimal (16 bytes) and IntPtr/UIntPtr
- GetActiveTab made const to support calls from RenderEditableProperty