### PR TITLE
fix(lua): defer initialization and disable JIT to stabilize injection

### DIFF
--- a/UnityInspector/src/config/config.h
+++ b/UnityInspector/src/config/config.h
@@ -30,6 +30,7 @@ struct UserSettings
 		bool avoid_quiting = false;
 		bool internal_overlay = true;
 		bool external_overlay = false;
+		bool lua_jit_enabled = false;
 	} ini;
 
 	struct InspectorSettings
@@ -69,6 +70,7 @@ struct UserSettings
 				if (c.contains("avoid_quiting"))     ini.avoid_quiting = c["avoid_quiting"].as<bool>();
 				if (c.contains("internal_overlay"))  ini.internal_overlay = c["internal_overlay"].as<bool>();
 				if (c.contains("external_overlay"))  ini.external_overlay = c["external_overlay"].as<bool>();
+				if (c.contains("lua_jit_enabled"))   ini.lua_jit_enabled = c["lua_jit_enabled"].as<bool>();
 			}
 		}
 		catch (...)

--- a/UnityInspector/src/features/features.cpp
+++ b/UnityInspector/src/features/features.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 #include "features.h"
+#include "lua_system/lua_system.h"
+#include "lua_system/lua_plugin.h"
 
 void IFeature::Init()
 {
@@ -17,6 +19,8 @@ namespace Features
 	{
 		for (auto& factory : GetRegistry())
 			features.push_back(factory());
+
+		features.push_back(std::make_unique<LuaSystem>());
 
 		for (const auto& feature : features)
 			feature->Init();

--- a/UnityInspector/src/features/lua_system/lua_system.cpp
+++ b/UnityInspector/src/features/lua_system/lua_system.cpp
@@ -3,19 +3,31 @@
 #include "lua_plugin.h"
 #include "lua_bindings.h"
 #include "features/debug_console/debug_console.h"
+#include "config/config.h"
 
-REGISTER_FEATURE(LuaSystem)
+//REGISTER_FEATURE(LuaSystem)  // manually registered in features.cpp to avoid static init crash
 
 void LuaSystem::Init()
 {
 	s_Instance = this;
+}
+
+void LuaSystem::EnsureInitialized()
+{
+	if (initialized) return;
+	if (luaState) return;
+
 	try
 	{
-		LuaBindings::RegisterAll(luaState);
+		luaState = std::make_unique<sol::state>();
 
-		textEditor.SetLanguageDefinition(TextEditor::LanguageDefinition::Lua());
-		textEditor.SetPalette(TextEditor::GetDarkPalette());
-		textEditor.SetShowWhitespaces(false);
+		if (!Config::settings.ini.lua_jit_enabled)
+			luaJIT_setmode(luaState->lua_state(), 0, LUAJIT_MODE_ENGINE | LUAJIT_MODE_OFF);
+
+		textEditor = std::make_unique<TextEditor>();
+		textEditor->SetLanguageDefinition(TextEditor::LanguageDefinition::Lua());
+		textEditor->SetPalette(TextEditor::GetDarkPalette());
+		textEditor->SetShowWhitespaces(false);
 
 		char buffer[MAX_PATH];
 		GetModuleFileNameA(nullptr, buffer, MAX_PATH);
@@ -27,19 +39,30 @@ void LuaSystem::Init()
 			LOG_INFO("Created plugins directory: {}", pluginsDir.string());
 		}
 
+		LuaBindings::RegisterAll(*luaState);
 		ScanPlugins();
 		initialized = true;
-		LOG_INFO("LuaSystem initialized. Plugins dir: {}", pluginsDir.string());
+		LOG_INFO("LuaSystem initialized. JIT: {}", Config::settings.ini.lua_jit_enabled ? "ON" : "OFF");
 	}
 	catch (const std::exception& e)
 	{
 		LOG_ERROR("LuaSystem init failed: {}", e.what());
 		DebugConsole::AddLog(std::format("LuaSystem init failed: {}", e.what()), LogType::Error);
+		luaState.reset();
+		textEditor.reset();
+	}
+	catch (...)
+	{
+		LOG_ERROR("LuaSystem init failed: SEH exception caught");
+		DebugConsole::AddLog("LuaSystem init failed: SEH exception caught", LogType::Error);
+		luaState.reset();
+		textEditor.reset();
 	}
 }
 
 void LuaSystem::ScanPlugins()
 {
+	if (!luaState) return;
 	plugins.clear();
 
 	if (!std::filesystem::exists(pluginsDir))
@@ -50,7 +73,7 @@ void LuaSystem::ScanPlugins()
 		if (!entry.is_regular_file()) continue;
 		if (entry.path().extension() != ".lua") continue;
 
-		auto plugin = std::make_unique<LuaPlugin>(luaState, entry.path());
+		auto plugin = std::make_unique<LuaPlugin>(*luaState, entry.path());
 		plugin->Init();
 		plugins.push_back(std::move(plugin));
 	}
@@ -58,6 +81,7 @@ void LuaSystem::ScanPlugins()
 
 void LuaSystem::CheckHotReload()
 {
+	if (!luaState) return;
 	if (!std::filesystem::exists(pluginsDir))
 		return;
 
@@ -97,7 +121,7 @@ void LuaSystem::CheckHotReload()
 			}
 			else
 			{
-				auto plugin = std::make_unique<LuaPlugin>(luaState, entry.path());
+				auto plugin = std::make_unique<LuaPlugin>(*luaState, entry.path());
 				plugin->Init();
 				LOG_INFO("Loaded new plugin: {}", plugin->GetName());
 				plugins.push_back(std::move(plugin));
@@ -161,7 +185,7 @@ void LuaSystem::RenderLuaConsole()
 	{
 		if (ImGui::Button("Execute", ImVec2(100, 0)))
 		{
-			if (std::string code = textEditor.GetText(); !code.empty())
+			if (std::string code = textEditor->GetText(); !code.empty())
 			{
 				ExecuteString(code);
 			}
@@ -169,30 +193,32 @@ void LuaSystem::RenderLuaConsole()
 		ImGui::SameLine();
 		if (ImGui::Button("Clear", ImVec2(100, 0)))
 		{
-			textEditor.SetText("");
+			textEditor->SetText("");
 		}
 
 		ImGui::Spacing();
 
-		textEditor.Render("##LuaConsole", ImVec2(-1, ImGui::GetContentRegionAvail().y), true);
+		textEditor->Render("##LuaConsole", ImVec2(-1, ImGui::GetContentRegionAvail().y), true);
 	}
 	ImGui::End();
 }
 
 void LuaSystem::ReloadAll()
 {
+	EnsureInitialized();
 	if (!initialized) return;
 	ScanPlugins();
 }
 
 void LuaSystem::ExecuteString(const std::string& code)
 {
-	if (!initialized) return;
+	EnsureInitialized();
+	if (!initialized || !luaState) return;
 
 	try
 	{
 		UR::ThreadAttach();
-		if (sol::protected_function_result result = luaState.safe_script(code); !result.valid())
+		if (sol::protected_function_result result = luaState->safe_script(code); !result.valid())
 		{
 			sol::error err = result;
 			DebugConsole::AddLog(std::format("Lua console error: {}", err.what()), LogType::Error);

--- a/UnityInspector/src/features/lua_system/lua_system.h
+++ b/UnityInspector/src/features/lua_system/lua_system.h
@@ -13,9 +13,10 @@ public:
 
 	void ReloadAll();
 	void ExecuteString(const std::string& code);
+	void EnsureInitialized();
 	bool IsReady() const { return initialized; }
 
-	sol::state& GetState() { return luaState; }
+	sol::state& GetState() { return *luaState; }
 	std::vector<std::unique_ptr<LuaPlugin>>& GetPlugins() { return plugins; }
 
 	bool IsConsoleVisible() const { return showConsole; }
@@ -25,7 +26,7 @@ public:
 
 private:
 	static inline LuaSystem* s_Instance = nullptr;
-	sol::state luaState;
+	std::unique_ptr<sol::state> luaState;
 	std::vector<std::unique_ptr<LuaPlugin>> plugins;
 	std::filesystem::path pluginsDir;
 	bool initialized = false;
@@ -33,7 +34,7 @@ private:
 	float reloadTimer = 0.0f;
 	static constexpr float RELOAD_INTERVAL = .5f;
 
-	TextEditor textEditor;
+	std::unique_ptr<TextEditor> textEditor;
 
 	void ScanPlugins();
 	void CheckHotReload();

--- a/UnityInspector/src/menu/lua_tab/lua_tab.cpp
+++ b/UnityInspector/src/menu/lua_tab/lua_tab.cpp
@@ -7,62 +7,72 @@ void LuaConsoleTab::Render()
 {
 	ImGui::BeginChild("LuaTab", ImVec2(0, 0), true);
 
-	ImGui::Text("Lua Plugins");
-	ImGui::Separator();
-	ImGui::Spacing();
-
 	if (auto* luaSystem = LuaSystem::GetInstance())
 	{
-		bool consoleVisible = luaSystem->IsConsoleVisible();
-		if (ImGui::Checkbox("Show Lua Console", &consoleVisible))
-			luaSystem->SetConsoleVisible(consoleVisible);
-
-		ImGui::Spacing();
-		ImGui::Separator();
-		ImGui::Spacing();
-
-		if (ImGui::Button("Reload All Plugins", ImVec2(150, 0)))
-			luaSystem->ReloadAll();
-
-		ImGui::Spacing();
-		ImGui::Text("Loaded Plugins (%zu):", luaSystem->GetPlugins().size());
-		ImGui::Spacing();
-
-		for (size_t i = 0; i < luaSystem->GetPlugins().size(); ++i)
+		if (!luaSystem->IsReady())
 		{
-			auto& plugin = luaSystem->GetPlugins()[i];
-			ImGui::PushID(static_cast<int>(i));
+			ImGui::TextDisabled("Lua not initialized");
+			ImGui::Spacing();
+			if (ImGui::Button("Initialize Lua", ImVec2(150, 0)))
+				luaSystem->EnsureInitialized();
+		}
+		else
+		{
+			ImGui::Text("Lua Plugins");
+			ImGui::Separator();
+			ImGui::Spacing();
 
-			bool enabled = plugin->IsEnabled();
-			if (ImGui::Checkbox(plugin->GetName().c_str(), &enabled))
-				plugin->SetEnabled(enabled);
+			bool consoleVisible = luaSystem->IsConsoleVisible();
+			if (ImGui::Checkbox("Show Lua Console", &consoleVisible))
+				luaSystem->SetConsoleVisible(consoleVisible);
 
-			if (plugin->HasError())
+			ImGui::Spacing();
+			ImGui::Separator();
+			ImGui::Spacing();
+
+			if (ImGui::Button("Reload All Plugins", ImVec2(150, 0)))
+				luaSystem->ReloadAll();
+
+			ImGui::Spacing();
+			ImGui::Text("Loaded Plugins (%zu):", luaSystem->GetPlugins().size());
+			ImGui::Spacing();
+
+			for (size_t i = 0; i < luaSystem->GetPlugins().size(); ++i)
 			{
+				auto& plugin = luaSystem->GetPlugins()[i];
+				ImGui::PushID(static_cast<int>(i));
+
+				bool enabled = plugin->IsEnabled();
+				if (ImGui::Checkbox(plugin->GetName().c_str(), &enabled))
+					plugin->SetEnabled(enabled);
+
+				if (plugin->HasError())
+				{
+					ImGui::SameLine();
+					ImGui::TextColored(ImVec4(1, 0, 0, 1), "[ERROR]");
+					if (ImGui::IsItemHovered())
+						ImGui::SetTooltip("%s", plugin->GetError().c_str());
+				}
+
 				ImGui::SameLine();
-				ImGui::TextColored(ImVec4(1, 0, 0, 1), "[ERROR]");
-				if (ImGui::IsItemHovered())
-					ImGui::SetTooltip("%s", plugin->GetError().c_str());
-			}
+				if (plugin->IsLoaded())
+				{
+					if (ImGui::SmallButton("Unload"))
+						plugin->Unload();
+				}
+				else
+				{
+					if (ImGui::SmallButton("Reload"))
+						plugin->Reload();
+				}
 
-			ImGui::SameLine();
-			if (plugin->IsLoaded())
-			{
-				if (ImGui::SmallButton("Unload"))
-					plugin->Unload();
+				ImGui::PopID();
 			}
-			else
-			{
-				if (ImGui::SmallButton("Reload"))
-					plugin->Reload();
-			}
-
-			ImGui::PopID();
 		}
 	}
 	else
 	{
-		ImGui::TextDisabled("LuaSystem not initialized");
+		ImGui::TextDisabled("LuaSystem unavailable");
 	}
 
 	ImGui::EndChild();

--- a/UnityInspector/src/pch/pch.h
+++ b/UnityInspector/src/pch/pch.h
@@ -56,6 +56,9 @@
 
 // Lua
 #include "sol/sol.hpp"
+extern "C" {
+#include "luajit/luajit.h"
+}
 
 // Macros
 #define TOKENPASTE(x, y) x ## y


### PR DESCRIPTION
- Heap-allocate sol::state and TextEditor via unique_ptr to defer construction
- Trigger Lua init only on user click via "Initialize Lua" button in Lua tab
- Disable LuaJIT JIT compiler by default (configurable via lua_jit_enabled)
- Replace REGISTER_FEATURE static registration with manual create in Features::Init() to avoid static initialization crash during DLL load
- Add SEH catch(...) handler for access violation resilience during state creation
- Add null pointer guards across all LuaSystem methods